### PR TITLE
Improve report generation and Slack workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ reportbot
 *.db
 reports/
 config.yaml
+env
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,4 @@ WORKDIR /app
 COPY --from=builder /app/reportbot .
 RUN mkdir -p /app/reports
 
-ENV DB_PATH=/app/reportbot.db
-ENV REPORT_OUTPUT_DIR=/app/reports
-
 ENTRYPOINT ["./reportbot"]

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 A Slack bot that helps a development team track weekly work items and generate categorized markdown reports.
 
-Developers report completed work via slash commands. The bot also pulls merged GitLab merge requests automatically. An LLM (Anthropic Claude or OpenAI) classifies items into report categories.
+Developers report completed work via slash commands. The bot also pulls merged/open GitLab merge requests automatically. An LLM (Anthropic Claude or OpenAI) classifies items into sections derived from the previous report.
 
 ## Features
 
 - `/report` — Developers report work items via Slack
-- `/fetch-mrs` — Pull merged GitLab MRs for the current calendar week
-- `/generate-report` — AI-categorize items and generate a markdown report
+- `/fetch-mrs` — Pull merged and open GitLab MRs for the current calendar week
+- `/generate-report` — Generate a team markdown file (or boss `.eml` draft) and upload it to Slack
 - `/list-items` — View this week's items
+- `/list-missing` — Managers: list team members who have not reported this week
+- `/nudge [@name]` — Managers: send reminder DMs (missing members by default)
+- `/help` — Show all commands and example usage
 - Two report modes: **team** (author per line) and **boss** (authors grouped by category)
 - Manager-only permissions for report generation and MR fetching
 - **Weekly nudge** — Automatically DMs team members on a configurable day to remind them to report
@@ -25,14 +28,18 @@ Developers report completed work via slash commands. The bot also pulls merged G
    - `commands`
    - `files:write`
    - `im:write` (for Friday nudge DMs)
+   - `users:read` (to resolve full names for managers/team members)
 4. Under **Slash Commands**, create these four commands:
 
    | Command | Description |
    |---|---|
    | `/report` | Report a completed work item |
-   | `/fetch-mrs` | Fetch merged GitLab MRs for this week |
+   | `/fetch-mrs` | Fetch merged and open GitLab MRs for this week |
    | `/generate-report` | Generate the weekly report |
    | `/list-items` | List this week's work items |
+   | `/list-missing` | List team members missing reports |
+   | `/nudge [@name]` | Send reminder DMs |
+   | `/help` | Show help and usage |
 
 5. Install the app to your workspace
 
@@ -60,31 +67,36 @@ gitlab_group_id: "my-team"
 
 # LLM
 llm_provider: "anthropic"       # "anthropic" or "openai"
+llm_batch_size: 50              # optional: items per LLM classification batch
+llm_confidence_threshold: 0.70  # optional: route below-threshold to Undetermined
+llm_example_count: 20           # optional: prior-report examples included in prompt
+llm_example_max_chars: 140      # optional: max chars per example snippet
+llm_glossary_path: "./llm_glossary.yaml"    # optional glossary memory file
 anthropic_api_key: "sk-ant-..."
 
-# Permissions
-manager_slack_ids:
-  - "U01ABC123"
+# Permissions (Slack full names)
+manager:
+  - "Alice Smith"
 
-# Team members (Slack user IDs) - receive nudge reminders
+# Team members (Slack full names) - receive nudge reminders
 team_members:
-  - "U01ABC123"
-  - "U02DEF456"
+  - "Alice Smith"
+  - "Bob Lee"
 
-# Day and time to send nudge (local timezone)
+# Day and time to send nudge (configured timezone)
 nudge_day: "Friday"
 nudge_time: "10:00"
+monday_cutoff_time: "12:00"  # Monday before this time uses previous week
+
+# Timezone for week range and nudge scheduling (IANA format)
+timezone: "America/Los_Angeles"
 
 # Team name (used in report header and filename)
 team_name: "My Team"
 
-# Report categories (order = section order in report)
-categories:
-  - "Backend"
-  - "Frontend"
-  - "Infrastructure"
-  - "Bug Fixes"
-  - "Documentation"
+# Report channel (Slack channel ID for reminders)
+report_channel_id: "C01234567"
+
 ```
 
 Set `CONFIG_PATH` env var to load from a different path (default: `./config.yaml`).
@@ -99,10 +111,18 @@ export GITLAB_TOKEN=glpat-...
 export GITLAB_GROUP_ID=my-team
 export LLM_PROVIDER=anthropic
 export ANTHROPIC_API_KEY=sk-ant-...
-export MANAGER_SLACK_IDS=U01ABC123      # Comma-separated Slack user IDs
+export LLM_BATCH_SIZE=50
+export LLM_CONFIDENCE_THRESHOLD=0.70
+export LLM_EXAMPLE_COUNT=20
+export LLM_EXAMPLE_MAX_CHARS=140
+export LLM_GLOSSARY_PATH=./llm_glossary.yaml
+export MANAGER="Alice Smith,Bob Lee"   # Comma-separated Slack full names
+export REPORT_CHANNEL_ID=C01234567
+export MONDAY_CUTOFF_TIME=12:00
+export TIMEZONE=America/Los_Angeles
 ```
 
-Note: Categories cannot be configured via env vars — use `config.yaml` for that.
+Note: Category/subcategory headings are sourced from the previous report in `report_output_dir`.
 
 #### LLM Provider Defaults
 
@@ -112,6 +132,24 @@ Note: Categories cannot be configured via env vars — use `config.yaml` for tha
 | `openai` | `gpt-4o` |
 
 Set `llm_model` in YAML or `LLM_MODEL` env var to override.
+Set `llm_batch_size` / `LLM_BATCH_SIZE`, `llm_confidence_threshold` / `LLM_CONFIDENCE_THRESHOLD`, and `llm_example_count` / `llm_example_max_chars` to tune throughput, confidence gating, and prompt context size.
+Set `llm_glossary_path` / `LLM_GLOSSARY_PATH` to apply glossary memory rules (see `llm_glossary.example.yaml`).
+
+Glossary example (`llm_glossary.yaml`):
+
+```yaml
+terms:
+  - phrase: "adom pending"
+    section: "Cluster Manager"
+  - phrase: "kudu backup"
+    section: "Top Focus > HA Log Sync Enhancement"
+
+status_hints:
+  - phrase: "in qa"
+    status: "in testing"
+  - phrase: "qa passed"
+    status: "done"
+```
 
 ### 3. Build & Run
 
@@ -134,7 +172,9 @@ docker build -t reportbot .
 ```bash
 docker run -d --name reportbot \
   -v /path/to/config.yaml:/app/config.yaml:ro \
+  -v /path/to/llm_glossary.yaml:/app/llm_glossary.yaml:ro \
   -v reportbot-data:/app/data \
+  -v reports:/app/reports \
   reportbot
 ```
 
@@ -149,8 +189,12 @@ docker run -d --name reportbot \
   -e GITLAB_GROUP_ID=my-team \
   -e LLM_PROVIDER=anthropic \
   -e ANTHROPIC_API_KEY=sk-ant-... \
-  -e MANAGER_SLACK_IDS=U01ABC123 \
-  -v reportbot-data:/app \
+  -e MANAGER="Alice Smith,Bob Lee" \
+  -e REPORT_CHANNEL_ID=C01234567 \
+  -e MONDAY_CUTOFF_TIME=12:00 \
+  -e TIMEZONE=America/Los_Angeles \
+  -v reportbot-data:/app/data \
+  -v reports:/app/reports \
   reportbot
 ```
 
@@ -167,6 +211,14 @@ Any developer can report items:
 /report Migrate auth service to Redis session store (in progress)
 /report Fix flaky integration tests in CI (in testing)
 ```
+
+Managers can report on behalf of a team member:
+
+```
+/report {Alice} Research for agentic AI (in progress)
+```
+
+Delegated names support fuzzy matching against `team_members` (for example `{Rick}` -> `Rick Zheng`).
 
 Status is auto-extracted from the trailing parenthetical. Defaults to `done` if omitted.
 
@@ -185,8 +237,8 @@ Duplicates are skipped automatically based on MR URL.
 Manager only. Two modes:
 
 ```
-/generate-report team    # Author name on each line (default)
-/generate-report boss    # Authors grouped in category header
+/generate-report team    # Generate team markdown (.md) and upload file to Slack (default)
+/generate-report boss    # Generate boss email draft (.eml) and upload file to Slack
 ```
 
 **Team mode** output:
@@ -207,7 +259,7 @@ Manager only. Two modes:
 - Optimize database query for dashboard metrics (done)
 ```
 
-The report is posted to the Slack channel and saved to `REPORT_OUTPUT_DIR`.
+Generated files are saved to `REPORT_OUTPUT_DIR` and uploaded to the Slack channel as files.
 
 ### Listing Items
 
@@ -221,27 +273,24 @@ Anyone can view this week's items:
 
 Every week on `nudge_day` (default Friday) at `nudge_time` (default 10:00 AM local), the bot DMs each user in `team_members` reminding them to report. To disable, leave `team_members` empty.
 
+On Monday before `monday_cutoff_time` (default `12:00`) in configured `timezone`, report commands use the previous calendar week.
+
 Accepts any day name: `Monday`, `Tuesday`, ..., `Sunday`.
 
 Requires the `im:write` bot token scope in your Slack app.
 
 ## Permissions
 
-Manager commands (`/fetch-mrs`, `/generate-report`) are restricted to Slack user IDs listed in `MANAGER_SLACK_IDS`.
+Manager commands (`/fetch-mrs`, `/generate-report`, `/list-missing`) are restricted to Slack full names listed in `manager`.
+Manager commands include: `/fetch-mrs`, `/generate-report`, `/list-missing`, `/nudge`.
 
-To find your Slack user ID: click your profile picture → **Profile** → click the **⋮** menu → **Copy member ID**.
+## Report Structure
 
-## Report Categories
+Report sections and sub-sections are sourced from the previous generated team report. Their order is preserved exactly.
 
-Items are auto-classified by the LLM into configured categories. Defaults:
+`/generate-report team` writes the team-mode markdown report to `report_output_dir`.
 
-- Backend
-- Frontend
-- Infrastructure
-- Bug Fixes
-- Documentation
-
-Customize categories in `config.yaml` under the `categories` key. The order in the list determines the section order in the generated report.
+`/generate-report boss` is derived from the generated team report for the same week and posted to Slack without writing a separate boss file.
 
 ## Project Structure
 

--- a/config.go
+++ b/config.go
@@ -1,20 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
-
-var defaultCategories = []string{
-	"Backend",
-	"Frontend",
-	"Infrastructure",
-	"Bug Fixes",
-	"Documentation",
-}
 
 type Config struct {
 	SlackBotToken string `yaml:"slack_bot_token"`
@@ -24,20 +19,27 @@ type Config struct {
 	GitLabToken   string `yaml:"gitlab_token"`
 	GitLabGroupID string `yaml:"gitlab_group_id"`
 
-	LLMProvider     string `yaml:"llm_provider"`
-	LLMModel        string `yaml:"llm_model"`
-	AnthropicAPIKey string `yaml:"anthropic_api_key"`
-	OpenAIAPIKey    string `yaml:"openai_api_key"`
+	LLMProvider      string  `yaml:"llm_provider"`
+	LLMModel         string  `yaml:"llm_model"`
+	LLMBatchSize     int     `yaml:"llm_batch_size"`
+	LLMConfidence    float64 `yaml:"llm_confidence_threshold"`
+	LLMExampleCount  int     `yaml:"llm_example_count"`
+	LLMExampleMaxLen int     `yaml:"llm_example_max_chars"`
+	LLMGlossaryPath  string  `yaml:"llm_glossary_path"`
+	AnthropicAPIKey  string  `yaml:"anthropic_api_key"`
+	OpenAIAPIKey     string  `yaml:"openai_api_key"`
 
 	DBPath          string `yaml:"db_path"`
 	ReportOutputDir string `yaml:"report_output_dir"`
+	ReportChannelID string `yaml:"report_channel_id"`
 
-	ManagerSlackIDs []string `yaml:"manager_slack_ids"`
-	TeamMembers     []string `yaml:"team_members"`
-	NudgeDay        string   `yaml:"nudge_day"`
-	NudgeTime       string   `yaml:"nudge_time"`
-	Categories      []string `yaml:"categories"`
-	TeamName        string   `yaml:"team_name"`
+	Managers         []string `yaml:"manager"`
+	TeamMembers      []string `yaml:"team_members"`
+	NudgeDay         string   `yaml:"nudge_day"`
+	NudgeTime        string   `yaml:"nudge_time"`
+	MondayCutoffTime string   `yaml:"monday_cutoff_time"`
+	Timezone         string   `yaml:"timezone"`
+	TeamName         string   `yaml:"team_name"`
 }
 
 func LoadConfig() Config {
@@ -63,20 +65,28 @@ func LoadConfig() Config {
 	envOverride(&cfg.GitLabGroupID, "GITLAB_GROUP_ID")
 	envOverride(&cfg.LLMProvider, "LLM_PROVIDER")
 	envOverride(&cfg.LLMModel, "LLM_MODEL")
+	envOverrideInt(&cfg.LLMBatchSize, "LLM_BATCH_SIZE")
+	envOverrideFloat(&cfg.LLMConfidence, "LLM_CONFIDENCE_THRESHOLD")
+	envOverrideInt(&cfg.LLMExampleCount, "LLM_EXAMPLE_COUNT")
+	envOverrideInt(&cfg.LLMExampleMaxLen, "LLM_EXAMPLE_MAX_CHARS")
+	envOverride(&cfg.LLMGlossaryPath, "LLM_GLOSSARY_PATH")
 	envOverride(&cfg.AnthropicAPIKey, "ANTHROPIC_API_KEY")
 	envOverride(&cfg.OpenAIAPIKey, "OPENAI_API_KEY")
 	envOverride(&cfg.DBPath, "DB_PATH")
 	envOverride(&cfg.ReportOutputDir, "REPORT_OUTPUT_DIR")
+	envOverride(&cfg.ReportChannelID, "REPORT_CHANNEL_ID")
 	envOverride(&cfg.TeamName, "TEAM_NAME")
 	envOverride(&cfg.NudgeDay, "NUDGE_DAY")
 	envOverride(&cfg.NudgeTime, "NUDGE_TIME")
+	envOverride(&cfg.MondayCutoffTime, "MONDAY_CUTOFF_TIME")
+	envOverride(&cfg.Timezone, "TIMEZONE")
 
-	if ids := os.Getenv("MANAGER_SLACK_IDS"); ids != "" {
-		cfg.ManagerSlackIDs = nil
-		for _, id := range strings.Split(ids, ",") {
-			id = strings.TrimSpace(id)
-			if id != "" {
-				cfg.ManagerSlackIDs = append(cfg.ManagerSlackIDs, id)
+	if names := os.Getenv("MANAGER"); names != "" {
+		cfg.Managers = nil
+		for _, name := range strings.Split(names, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				cfg.Managers = append(cfg.Managers, name)
 			}
 		}
 	}
@@ -84,6 +94,18 @@ func LoadConfig() Config {
 	// Defaults
 	if cfg.LLMProvider == "" {
 		cfg.LLMProvider = "anthropic"
+	}
+	if cfg.LLMBatchSize == 0 {
+		cfg.LLMBatchSize = 50
+	}
+	if cfg.LLMConfidence == 0 {
+		cfg.LLMConfidence = 0.70
+	}
+	if cfg.LLMExampleCount == 0 {
+		cfg.LLMExampleCount = 20
+	}
+	if cfg.LLMExampleMaxLen == 0 {
+		cfg.LLMExampleMaxLen = 140
 	}
 	if cfg.DBPath == "" {
 		cfg.DBPath = "./reportbot.db"
@@ -97,13 +119,15 @@ func LoadConfig() Config {
 	if cfg.NudgeTime == "" {
 		cfg.NudgeTime = "10:00"
 	}
+	if cfg.MondayCutoffTime == "" {
+		cfg.MondayCutoffTime = "12:00"
+	}
 	if cfg.TeamName == "" {
 		cfg.TeamName = "My Team"
 	}
-	if len(cfg.Categories) == 0 {
-		cfg.Categories = defaultCategories
+	if cfg.Timezone == "" {
+		cfg.Timezone = "Local"
 	}
-
 	// Validate required fields
 	required := map[string]string{
 		"slack_bot_token": cfg.SlackBotToken,
@@ -131,6 +155,37 @@ func LoadConfig() Config {
 		log.Fatalf("llm_provider must be 'anthropic' or 'openai', got '%s'", cfg.LLMProvider)
 	}
 
+	if strings.EqualFold(cfg.Timezone, "Local") {
+		cfg.Timezone = time.Local.String()
+	} else {
+		loc, err := time.LoadLocation(cfg.Timezone)
+		if err != nil {
+			log.Fatalf("invalid timezone '%s': %v", cfg.Timezone, err)
+		}
+		time.Local = loc
+	}
+
+	if _, _, err := parseClock(cfg.MondayCutoffTime); err != nil {
+		log.Fatalf("invalid monday_cutoff_time '%s': %v", cfg.MondayCutoffTime, err)
+	}
+	if cfg.LLMBatchSize < 1 {
+		log.Fatalf("invalid llm_batch_size '%d': must be >= 1", cfg.LLMBatchSize)
+	}
+	if cfg.LLMConfidence < 0 || cfg.LLMConfidence > 1 {
+		log.Fatalf("invalid llm_confidence_threshold '%f': must be between 0 and 1", cfg.LLMConfidence)
+	}
+	if cfg.LLMExampleCount < 0 {
+		log.Fatalf("invalid llm_example_count '%d': must be >= 0", cfg.LLMExampleCount)
+	}
+	if cfg.LLMExampleMaxLen < 20 {
+		log.Fatalf("invalid llm_example_max_chars '%d': must be >= 20", cfg.LLMExampleMaxLen)
+	}
+	if cfg.LLMGlossaryPath != "" {
+		if _, err := LoadLLMGlossary(cfg.LLMGlossaryPath); err != nil {
+			log.Fatalf("invalid llm_glossary_path '%s': %v", cfg.LLMGlossaryPath, err)
+		}
+	}
+
 	return cfg
 }
 
@@ -140,11 +195,44 @@ func envOverride(field *string, envKey string) {
 	}
 }
 
-func (c Config) IsManager(slackUserID string) bool {
-	for _, id := range c.ManagerSlackIDs {
-		if id == slackUserID {
+func envOverrideInt(field *int, envKey string) {
+	if val := os.Getenv(envKey); val != "" {
+		parsed, err := strconv.Atoi(val)
+		if err != nil {
+			log.Fatalf("invalid %s '%s': %v", envKey, val, err)
+		}
+		*field = parsed
+	}
+}
+
+func envOverrideFloat(field *float64, envKey string) {
+	if val := os.Getenv(envKey); val != "" {
+		parsed, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			log.Fatalf("invalid %s '%s': %v", envKey, val, err)
+		}
+		*field = parsed
+	}
+}
+
+func (c Config) IsManagerName(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, manager := range c.Managers {
+		if strings.ToLower(strings.TrimSpace(manager)) == name {
 			return true
 		}
 	}
 	return false
+}
+
+func parseClock(s string) (int, int, error) {
+	var hour, min int
+	_, err := fmt.Sscanf(s, "%d:%d", &hour, &min)
+	if err != nil {
+		return 0, 0, err
+	}
+	if hour < 0 || hour > 23 || min < 0 || min > 59 {
+		return 0, 0, fmt.Errorf("time out of range: %02d:%02d", hour, min)
+	}
+	return hour, min, nil
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+# export SLACK_BOT_TOKEN=xxxx
+# export SLACK_APP_TOKEN=xxxx
+# export GITLAB_TOKEN=xxxx
+# export OPENAI_API_KEY=xxxx
+# docker-compose --project-name reportbot up
+# docker-compose --project-name reportbot down
+services:
+  reportbot:
+    container_name: reportbot
+    image: reportbot
+    environment:
+      SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
+      SLACK_APP_TOKEN: "${SLACK_APP_TOKEN}"
+      GITLAB_TOKEN: "${GITLAB_TOKEN}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
+    volumes:
+      - /Users/wli02/Documents/workspace_work/WZ/reportbot/config.yaml:/app/config.yaml:ro
+      - /Users/wli02/Documents/workspace_work/WZ/reportbot/reportbot-data:/app/data
+      - /Users/wli02/Documents/workspace_work/WZ/reportbot/reportbot-reports:/app/reports
+      - /Users/wli02/Documents/workspace_work/WZ/reportbot/llm_glossary.yaml:/app/llm_glossary.yaml:ro

--- a/glossary.go
+++ b/glossary.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type LLMGlossary struct {
+	Terms       []GlossaryTerm       `yaml:"terms"`
+	StatusHints []GlossaryStatusHint `yaml:"status_hints"`
+}
+
+type GlossaryTerm struct {
+	Phrase  string `yaml:"phrase"`
+	Section string `yaml:"section"`
+}
+
+type GlossaryStatusHint struct {
+	Phrase string `yaml:"phrase"`
+	Status string `yaml:"status"`
+}
+
+func LoadLLMGlossary(path string) (*LLMGlossary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read glossary: %w", err)
+	}
+	var g LLMGlossary
+	if err := yaml.Unmarshal(data, &g); err != nil {
+		return nil, fmt.Errorf("parse glossary yaml: %w", err)
+	}
+	return &g, nil
+}
+
+func normalizeTextToken(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/llm.go
+++ b/llm.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
@@ -13,98 +14,277 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 )
 
-type classifiedItem struct {
-	ID        int64  `json:"id"`
-	Category  string `json:"category"`
-	TicketIDs string `json:"ticket_ids"`
+type sectionClassifiedItem struct {
+	ID               int64   `json:"id"`
+	SectionID        string  `json:"section_id"`
+	NormalizedStatus string  `json:"normalized_status"`
+	TicketIDs        string  `json:"ticket_ids"`
+	DuplicateOf      string  `json:"duplicate_of"`
+	Confidence       float64 `json:"confidence"`
+}
+
+type existingItemContext struct {
+	Key         string
+	SectionID   string
+	Description string
+	Status      string
+}
+
+type LLMSectionDecision struct {
+	SectionID        string
+	NormalizedStatus string
+	TicketIDs        string
+	DuplicateOf      string
+	Confidence       float64
+}
+
+type LLMUsage struct {
+	InputTokens  int64
+	OutputTokens int64
+}
+
+func (u LLMUsage) TotalTokens() int64 {
+	return u.InputTokens + u.OutputTokens
+}
+
+func (u *LLMUsage) Add(other LLMUsage) {
+	u.InputTokens += other.InputTokens
+	u.OutputTokens += other.OutputTokens
 }
 
 const defaultAnthropicModel = "claude-sonnet-4-5-20250929"
-const defaultOpenAIModel = "gpt-4o"
+const defaultOpenAIModel = "gpt-4o-mini"
 
-func CategorizeItems(cfg Config, items []WorkItem) (map[int64]string, map[int64]string, error) {
+func CategorizeItemsToSections(
+	cfg Config,
+	items []WorkItem,
+	options []sectionOption,
+	existing []existingItemContext,
+) (map[int64]LLMSectionDecision, LLMUsage, error) {
 	if len(items) == 0 {
-		return nil, nil, nil
+		return nil, LLMUsage{}, nil
 	}
 
-	systemPrompt, userPrompt := buildPrompts(cfg.Categories, items)
-
-	var responseText string
-	var err error
-
-	switch cfg.LLMProvider {
-	case "openai":
-		model := cfg.LLMModel
-		if model == "" {
-			model = defaultOpenAIModel
-		}
-		responseText, err = callOpenAI(cfg.OpenAIAPIKey, model, systemPrompt, userPrompt)
-	default:
-		model := cfg.LLMModel
-		if model == "" {
-			model = defaultAnthropicModel
-		}
-		responseText, err = callAnthropic(cfg.AnthropicAPIKey, model, systemPrompt, userPrompt)
+	batchSize := cfg.LLMBatchSize
+	if batchSize < 1 {
+		batchSize = 50
 	}
+	all := make(map[int64]LLMSectionDecision, len(items))
+	totalUsage := LLMUsage{}
+	glossary, err := loadGlossaryIfConfigured(cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, LLMUsage{}, err
+	}
+	glossarySectionMap := resolveGlossarySectionMap(glossary, options)
+
+	for start := 0; start < len(items); start += batchSize {
+		end := start + batchSize
+		if end > len(items) {
+			end = len(items)
+		}
+		batch := items[start:end]
+		systemPrompt, userPrompt := buildSectionPrompts(cfg, options, batch, existing)
+
+		var responseText string
+		var usage LLMUsage
+		var err error
+
+		switch cfg.LLMProvider {
+		case "openai":
+			model := cfg.LLMModel
+			if model == "" {
+				model = defaultOpenAIModel
+			}
+			log.Printf("llm section-classify provider=openai model=%s items=%d sections=%d batch=%d-%d", model, len(batch), len(options), start, end)
+			responseText, usage, err = callOpenAI(cfg.OpenAIAPIKey, model, systemPrompt, userPrompt)
+		default:
+			model := cfg.LLMModel
+			if model == "" {
+				model = defaultAnthropicModel
+			}
+			log.Printf("llm section-classify provider=anthropic model=%s items=%d sections=%d batch=%d-%d", model, len(batch), len(options), start, end)
+			responseText, usage, err = callAnthropic(cfg.AnthropicAPIKey, model, systemPrompt, userPrompt)
+		}
+		if err != nil {
+			return nil, totalUsage, err
+		}
+		totalUsage.Add(usage)
+
+		parsed, err := parseSectionClassifiedResponse(responseText)
+		if err != nil {
+			return nil, totalUsage, err
+		}
+		applyGlossaryOverrides(batch, parsed, glossary, glossarySectionMap)
+		for id, decision := range parsed {
+			all[id] = decision
+		}
 	}
 
-	return parseClassifiedResponse(responseText)
+	return all, totalUsage, nil
 }
 
-func buildPrompts(categories []string, items []WorkItem) (string, string) {
-	var sb strings.Builder
-	for _, item := range items {
-		sb.WriteString(fmt.Sprintf("ID:%d - %s (by %s)\n", item.ID, item.Description, item.Author))
+func buildSectionPrompts(cfg Config, options []sectionOption, items []WorkItem, existing []existingItemContext) (string, string) {
+	var sectionLines strings.Builder
+	for _, option := range options {
+		sectionLines.WriteString(fmt.Sprintf("- %s: %s\n", option.ID, option.Label))
 	}
 
-	categoryList := strings.Join(categories, "\n- ")
+	var itemLines strings.Builder
+	for _, item := range items {
+		itemLines.WriteString(fmt.Sprintf("ID:%d - %s (status: %s)\n", item.ID, strings.TrimSpace(item.Description), normalizeStatus(item.Status)))
+	}
 
-	systemPrompt := fmt.Sprintf(`You are a work item classifier for a software development team.
-Classify each work item into exactly one of these categories:
-- %s
+	var existingLines strings.Builder
+	for _, ex := range existing {
+		existingLines.WriteString(fmt.Sprintf("- %s | %s | %s | %s\n", ex.Key, ex.SectionID, strings.TrimSpace(ex.Status), strings.TrimSpace(ex.Description)))
+	}
 
-Also extract any ticket IDs (numbers in square brackets like [1247202] or bare numbers like 1247202 that appear to be ticket references).
+	existingBlock := "none"
+	if existingLines.Len() > 0 {
+		existingBlock = existingLines.String()
+	}
 
-Respond with JSON only. No markdown fences. Format:
-[{"id": 1, "category": "Infrastructure", "ticket_ids": "1247202,1230118"}, ...]
+	examplesBlock := "none"
+	if len(existing) > 0 {
+		exampleCount := cfg.LLMExampleCount
+		exampleMaxLen := cfg.LLMExampleMaxLen
+		var examples strings.Builder
+		for i, ex := range existing {
+			if i >= exampleCount {
+				break
+			}
+			desc := strings.TrimSpace(ex.Description)
+			if len(desc) > exampleMaxLen {
+				desc = desc[:exampleMaxLen] + "..."
+			}
+			examples.WriteString(fmt.Sprintf("- EX|%s|%s\n", ex.SectionID, desc))
+		}
+		if examples.Len() > 0 {
+			examplesBlock = examples.String()
+		}
+	}
 
-If unsure about category, use "Uncategorized".`, categoryList)
+	systemPrompt := fmt.Sprintf(`You classify software work items into one section.
+Choose exactly one section_id for each item from:
+%s
 
-	userPrompt := "Classify these work items:\n\n" + sb.String()
+If none fit, use section_id "UND".
+Also:
+- choose normalized_status from: done, in testing, in progress, other
+- extract ticket IDs if present (e.g. [1247202] or bare ticket numbers)
+- if this item is the same underlying work as an existing item, set duplicate_of to that existing key (Kxx); otherwise empty string
+- set confidence between 0 and 1.
+
+Respond with JSON only (no markdown):
+[{"id": 1, "section_id": "S0_2", "normalized_status": "in progress", "ticket_ids": "1247202", "duplicate_of": "K3", "confidence": 0.91}, ...]`, sectionLines.String())
+
+	userPrompt := "Examples from previous reports:\n" + examplesBlock +
+		"\nExisting items (for duplicate_of):\n" + existingBlock +
+		"\nClassify these items:\n\n" + itemLines.String()
 	return systemPrompt, userPrompt
 }
 
-func parseClassifiedResponse(responseText string) (map[int64]string, map[int64]string, error) {
+func parseSectionClassifiedResponse(responseText string) (map[int64]LLMSectionDecision, error) {
 	responseText = strings.TrimSpace(responseText)
 	responseText = strings.TrimPrefix(responseText, "```json")
 	responseText = strings.TrimPrefix(responseText, "```")
 	responseText = strings.TrimSuffix(responseText, "```")
 	responseText = strings.TrimSpace(responseText)
 
-	var classified []classifiedItem
+	var classified []sectionClassifiedItem
 	if err := json.Unmarshal([]byte(responseText), &classified); err != nil {
-		return nil, nil, fmt.Errorf("parsing LLM response: %w (response: %s)", err, responseText)
+		return nil, fmt.Errorf("parsing LLM section response: %w (response: %s)", err, responseText)
 	}
 
-	categoryMap := make(map[int64]string)
-	ticketMap := make(map[int64]string)
+	decisions := make(map[int64]LLMSectionDecision)
 	for _, c := range classified {
-		if c.Category != "" {
-			categoryMap[c.ID] = c.Category
+		decisions[c.ID] = LLMSectionDecision{
+			SectionID:        strings.TrimSpace(c.SectionID),
+			NormalizedStatus: normalizeStatus(strings.TrimSpace(c.NormalizedStatus)),
+			TicketIDs:        strings.TrimSpace(c.TicketIDs),
+			DuplicateOf:      strings.TrimSpace(c.DuplicateOf),
+			Confidence:       c.Confidence,
 		}
-		if c.TicketIDs != "" {
-			ticketMap[c.ID] = c.TicketIDs
+	}
+	return decisions, nil
+}
+
+func loadGlossaryIfConfigured(cfg Config) (*LLMGlossary, error) {
+	if strings.TrimSpace(cfg.LLMGlossaryPath) == "" {
+		return nil, nil
+	}
+	return LoadLLMGlossary(cfg.LLMGlossaryPath)
+}
+
+func resolveGlossarySectionMap(glossary *LLMGlossary, options []sectionOption) map[string]string {
+	out := make(map[string]string)
+	if glossary == nil {
+		return out
+	}
+
+	byID := make(map[string]string)
+	byLabel := make(map[string]string)
+	for _, option := range options {
+		byID[normalizeTextToken(option.ID)] = option.ID
+		byLabel[normalizeTextToken(option.Label)] = option.ID
+		parts := strings.Split(option.Label, ">")
+		if len(parts) == 2 {
+			byLabel[normalizeTextToken(parts[0])] = option.ID
+			byLabel[normalizeTextToken(parts[1])] = option.ID
 		}
 	}
 
-	return categoryMap, ticketMap, nil
+	for _, term := range glossary.Terms {
+		target := normalizeTextToken(term.Section)
+		switch {
+		case byID[target] != "":
+			out[normalizeTextToken(term.Phrase)] = byID[target]
+		case byLabel[target] != "":
+			out[normalizeTextToken(term.Phrase)] = byLabel[target]
+		}
+	}
+	return out
+}
+
+func applyGlossaryOverrides(
+	items []WorkItem,
+	decisions map[int64]LLMSectionDecision,
+	glossary *LLMGlossary,
+	glossarySectionMap map[string]string,
+) {
+	if glossary == nil {
+		return
+	}
+
+	for _, item := range items {
+		desc := normalizeTextToken(item.Description)
+		decision := decisions[item.ID]
+
+		for phrase, sectionID := range glossarySectionMap {
+			if phrase != "" && strings.Contains(desc, phrase) {
+				decision.SectionID = sectionID
+				if decision.Confidence < 0.99 {
+					decision.Confidence = 0.99
+				}
+				break
+			}
+		}
+
+		for _, hint := range glossary.StatusHints {
+			phrase := normalizeTextToken(hint.Phrase)
+			if phrase != "" && strings.Contains(desc, phrase) {
+				decision.NormalizedStatus = normalizeStatus(hint.Status)
+				break
+			}
+		}
+
+		decisions[item.ID] = decision
+	}
 }
 
 // --- Anthropic ---
 
-func callAnthropic(apiKey, model, systemPrompt, userPrompt string) (string, error) {
+func callAnthropic(apiKey, model, systemPrompt, userPrompt string) (string, LLMUsage, error) {
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))
 
 	message, err := client.Messages.New(context.Background(), anthropic.MessageNewParams{
@@ -118,22 +298,28 @@ func callAnthropic(apiKey, model, systemPrompt, userPrompt string) (string, erro
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("Anthropic API error: %w", err)
+		log.Printf("llm anthropic error: %v", err)
+		return "", LLMUsage{}, fmt.Errorf("Anthropic API error: %w", err)
+	}
+	usage := LLMUsage{
+		InputTokens:  message.Usage.InputTokens,
+		OutputTokens: message.Usage.OutputTokens,
 	}
 
 	for _, block := range message.Content {
 		if block.Type == "text" {
-			return block.Text, nil
+			log.Printf("llm anthropic response size=%d tokens_in=%d tokens_out=%d", len(block.Text), usage.InputTokens, usage.OutputTokens)
+			return block.Text, usage, nil
 		}
 	}
-	return "", fmt.Errorf("no text content in Anthropic response")
+	return "", usage, fmt.Errorf("no text content in Anthropic response")
 }
 
 // --- OpenAI ---
 
 type openAIRequest struct {
-	Model    string           `json:"model"`
-	Messages []openAIMessage  `json:"messages"`
+	Model    string          `json:"model"`
+	Messages []openAIMessage `json:"messages"`
 }
 
 type openAIMessage struct {
@@ -147,12 +333,17 @@ type openAIResponse struct {
 			Content string `json:"content"`
 		} `json:"message"`
 	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+		TotalTokens      int64 `json:"total_tokens"`
+	} `json:"usage"`
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error"`
 }
 
-func callOpenAI(apiKey, model, systemPrompt, userPrompt string) (string, error) {
+func callOpenAI(apiKey, model, systemPrompt, userPrompt string) (string, LLMUsage, error) {
 	reqBody := openAIRequest{
 		Model: model,
 		Messages: []openAIMessage{
@@ -163,39 +354,47 @@ func callOpenAI(apiKey, model, systemPrompt, userPrompt string) (string, error) 
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("marshaling request: %w", err)
+		return "", LLMUsage{}, fmt.Errorf("marshaling request: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(bodyBytes))
 	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
+		return "", LLMUsage{}, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("OpenAI API error: %w", err)
+		log.Printf("llm openai error: %v", err)
+		return "", LLMUsage{}, fmt.Errorf("OpenAI API error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("reading response: %w", err)
+		return "", LLMUsage{}, fmt.Errorf("reading response: %w", err)
 	}
 
 	var openAIResp openAIResponse
 	if err := json.Unmarshal(respBody, &openAIResp); err != nil {
-		return "", fmt.Errorf("parsing OpenAI response: %w", err)
+		return "", LLMUsage{}, fmt.Errorf("parsing OpenAI response: %w", err)
 	}
 
 	if openAIResp.Error != nil {
-		return "", fmt.Errorf("OpenAI API error: %s", openAIResp.Error.Message)
+		log.Printf("llm openai api error: %s", openAIResp.Error.Message)
+		return "", LLMUsage{}, fmt.Errorf("OpenAI API error: %s", openAIResp.Error.Message)
 	}
 
 	if len(openAIResp.Choices) == 0 {
-		return "", fmt.Errorf("no choices in OpenAI response")
+		return "", LLMUsage{}, fmt.Errorf("no choices in OpenAI response")
+	}
+	usage := LLMUsage{}
+	if openAIResp.Usage != nil {
+		usage.InputTokens = openAIResp.Usage.PromptTokens
+		usage.OutputTokens = openAIResp.Usage.CompletionTokens
 	}
 
-	return openAIResp.Choices[0].Message.Content, nil
+	log.Printf("llm openai response size=%d tokens_in=%d tokens_out=%d", len(openAIResp.Choices[0].Message.Content), usage.InputTokens, usage.OutputTokens)
+	return openAIResp.Choices[0].Message.Content, usage, nil
 }

--- a/llm_glossary.yaml
+++ b/llm_glossary.yaml
@@ -1,0 +1,47 @@
+# LLM Glossary Memory
+# -------------------
+# Purpose:
+# - Provide deterministic phrase-based overrides for section placement and status normalization.
+# - Reduce ambiguity for team/domain-specific terms.
+#
+# How it works:
+# - terms: if item description contains "phrase" (case-insensitive), section is forced to "section".
+# - status_hints: if item description contains "phrase", status is forced to "status".
+# - If multiple phrases match, the first match in this file wins.
+# - Section value can be:
+#   1) full label (example: "Top Focus > HA Log Sync Enhancement")
+#   2) category label (example: "Infrastructure")
+#   3) section id if known (example: "S1_2")
+#
+# Status values supported:
+# - done
+# - in testing
+# - in progress
+# - other
+#
+# Setup:
+# - Set `llm_glossary_path` in config.yaml (or `LLM_GLOSSARY_PATH` env var).
+# - Leave unset to disable glossary memory.
+
+terms:
+  # Infrastructure
+  - phrase: "consul readiness"
+    section: "Infrastructure"
+  - phrase: "ptp"
+    section: "Infrastructure"
+  - phrase: "chrony"
+    section: "Infrastructure"
+  - phrase: "routing"
+    section: "Infrastructure"
+  - phrase: "subnet"
+    section: "Infrastructure"
+
+  # Data Pipeline
+  - phrase: "pipeline health check"
+    section: "Data Pipeline"
+  - phrase: "hyperscale logs lag"
+    section: "Data Pipeline"
+  - phrase: "kafka"
+    section: "Data Pipeline"
+  - phrase: "etl performance"
+    section: "Data Pipeline"

--- a/llm_test.go
+++ b/llm_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyGlossaryOverrides(t *testing.T) {
+	glossary := &LLMGlossary{
+		Terms: []GlossaryTerm{
+			{Phrase: "adom pending", Section: "Query Service"},
+		},
+		StatusHints: []GlossaryStatusHint{
+			{Phrase: "in qa", Status: "in testing"},
+		},
+	}
+	options := []sectionOption{
+		{ID: "S0_0", Label: "Infrastructure"},
+		{ID: "S1_0", Label: "Query Service"},
+	}
+	sectionMap := resolveGlossarySectionMap(glossary, options)
+
+	items := []WorkItem{
+		{ID: 1, Description: "Investigate ADOM pending issue in QA"},
+	}
+	decisions := map[int64]LLMSectionDecision{
+		1: {SectionID: "S0_0", Confidence: 0.20},
+	}
+
+	applyGlossaryOverrides(items, decisions, glossary, sectionMap)
+	got := decisions[1]
+
+	if got.SectionID != "S1_0" {
+		t.Fatalf("expected glossary to override section to S1_0, got %s", got.SectionID)
+	}
+	if got.NormalizedStatus != "in testing" {
+		t.Fatalf("expected glossary status override to in testing, got %s", got.NormalizedStatus)
+	}
+	if got.Confidence < 0.99 {
+		t.Fatalf("expected glossary override to raise confidence, got %f", got.Confidence)
+	}
+}
+
+func TestBuildSectionPrompts_UsesExampleLimits(t *testing.T) {
+	cfg := Config{
+		LLMExampleCount:  1,
+		LLMExampleMaxLen: 10,
+	}
+	options := []sectionOption{
+		{ID: "S0_0", Label: "Top Focus"},
+	}
+	items := []WorkItem{
+		{ID: 1, Description: "Current item"},
+	}
+	existing := []existingItemContext{
+		{SectionID: "S0_0", Description: "123456789012345"},
+		{SectionID: "S0_0", Description: "second example"},
+	}
+
+	_, userPrompt := buildSectionPrompts(cfg, options, items, existing)
+
+	if !strings.Contains(userPrompt, "EX|S0_0|1234567890...") {
+		t.Fatalf("expected first example to be truncated by max chars, prompt=%s", userPrompt)
+	}
+	if strings.Count(userPrompt, "EX|") != 1 {
+		t.Fatalf("expected only one prompt example due to llm_example_count, prompt=%s", userPrompt)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,14 +9,28 @@ import (
 
 func main() {
 	cfg := LoadConfig()
+	log.Printf(
+		"Config loaded. Team=%s Managers=%d TeamMembers=%d Timezone=%s LLMBatchSize=%d LLMConfidenceThreshold=%.2f LLMExampleCount=%d LLMExampleMaxChars=%d LLMGlossaryPath=%s",
+		cfg.TeamName,
+		len(cfg.Managers),
+		len(cfg.TeamMembers),
+		cfg.Timezone,
+		cfg.LLMBatchSize,
+		cfg.LLMConfidence,
+		cfg.LLMExampleCount,
+		cfg.LLMExampleMaxLen,
+		cfg.LLMGlossaryPath,
+	)
 
 	db, err := InitDB(cfg.DBPath)
 	if err != nil {
 		log.Fatalf("Failed to init database: %v", err)
 	}
+	log.Printf("Database initialized at %s", cfg.DBPath)
 	defer db.Close()
 
 	os.MkdirAll(cfg.ReportOutputDir, 0755)
+	log.Printf("Report output dir: %s", cfg.ReportOutputDir)
 
 	api := slack.New(
 		cfg.SlackBotToken,

--- a/models.go
+++ b/models.go
@@ -21,6 +21,9 @@ type GitLabMR struct {
 	AuthorName  string // display name
 	WebURL      string
 	MergedAt    time.Time
+	UpdatedAt   time.Time
+	CreatedAt   time.Time
+	State       string
 	Labels      []string
 	ProjectPath string
 }
@@ -34,6 +37,10 @@ type ReportSection struct {
 // CurrentWeekRange returns Monday 00:00:00 and next Monday 00:00:00 for the current calendar week.
 func CurrentWeekRange() (time.Time, time.Time) {
 	now := time.Now()
+	return CurrentWeekRangeAt(now)
+}
+
+func CurrentWeekRangeAt(now time.Time) (time.Time, time.Time) {
 	weekday := now.Weekday()
 	if weekday == time.Sunday {
 		weekday = 7
@@ -42,4 +49,19 @@ func CurrentWeekRange() (time.Time, time.Time) {
 	monday := time.Date(now.Year(), now.Month(), now.Day()-daysFromMonday, 0, 0, 0, 0, now.Location())
 	nextMonday := monday.AddDate(0, 0, 7)
 	return monday, nextMonday
+}
+
+func ReportWeekRange(cfg Config, now time.Time) (time.Time, time.Time) {
+	hour, min, err := parseClock(cfg.MondayCutoffTime)
+	if err != nil {
+		return CurrentWeekRangeAt(now)
+	}
+
+	if now.Weekday() == time.Monday {
+		cutoff := time.Date(now.Year(), now.Month(), now.Day(), hour, min, 0, 0, now.Location())
+		if now.Before(cutoff) {
+			return CurrentWeekRangeAt(now.AddDate(0, 0, -7))
+		}
+	}
+	return CurrentWeekRangeAt(now)
 }

--- a/models_test.go
+++ b/models_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReportWeekRangeMondayCutoff(t *testing.T) {
+	loc := time.FixedZone("UTC+0", 0)
+	cfg := Config{MondayCutoffTime: "12:00"}
+
+	mondayMorning := time.Date(2026, 2, 9, 9, 0, 0, 0, loc)
+	from, to := ReportWeekRange(cfg, mondayMorning)
+	if from.Format("20060102") != "20260202" || to.Format("20060102") != "20260209" {
+		t.Fatalf("expected previous week for Monday morning, got %s -> %s", from.Format("20060102"), to.Format("20060102"))
+	}
+
+	mondayAfternoon := time.Date(2026, 2, 9, 13, 0, 0, 0, loc)
+	from, to = ReportWeekRange(cfg, mondayAfternoon)
+	if from.Format("20060102") != "20260209" || to.Format("20060102") != "20260216" {
+		t.Fatalf("expected current week for Monday afternoon, got %s -> %s", from.Format("20060102"), to.Format("20060102"))
+	}
+}

--- a/report.go
+++ b/report.go
@@ -2,92 +2,13 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
-
-func GenerateReport(items []WorkItem, reportDate time.Time, mode string, categories []string, teamName string) string {
-	if mode == "" {
-		mode = "team"
-	}
-
-	sections := groupByCategory(items)
-
-	var buf strings.Builder
-	buf.WriteString(fmt.Sprintf("### %s %s\n\n", teamName, reportDate.Format("20060102")))
-
-	for _, cat := range categories {
-		section, ok := sections[cat]
-		if !ok || len(section) == 0 {
-			continue
-		}
-
-		authors := uniqueAuthors(section)
-
-		if mode == "boss" {
-			authorStr := ""
-			if len(authors) > 0 {
-				authorStr = " (" + strings.Join(authors, ", ") + ")"
-			}
-			buf.WriteString(fmt.Sprintf("#### %s%s\n\n", cat, authorStr))
-		} else {
-			buf.WriteString(fmt.Sprintf("#### %s\n\n", cat))
-		}
-
-		for _, item := range section {
-			prefix := ""
-			if item.TicketIDs != "" {
-				prefix = fmt.Sprintf("[%s] ", item.TicketIDs)
-			}
-
-			status := item.Status
-			if status == "" {
-				status = "done"
-			}
-
-			if mode == "team" {
-				buf.WriteString(fmt.Sprintf("- **%s** - %s%s (%s)\n", item.Author, prefix, item.Description, status))
-			} else {
-				buf.WriteString(fmt.Sprintf("- %s%s (%s)\n", prefix, item.Description, status))
-			}
-		}
-		buf.WriteString("\n")
-	}
-
-	// Handle uncategorized items
-	var uncategorized []WorkItem
-	for _, item := range items {
-		found := false
-		for _, cat := range categories {
-			if item.Category == cat {
-				found = true
-				break
-			}
-		}
-		if !found {
-			uncategorized = append(uncategorized, item)
-		}
-	}
-	if len(uncategorized) > 0 {
-		buf.WriteString("#### Uncategorized\n\n")
-		for _, item := range uncategorized {
-			status := item.Status
-			if status == "" {
-				status = "done"
-			}
-			if mode == "team" {
-				buf.WriteString(fmt.Sprintf("- **%s** - %s (%s)\n", item.Author, item.Description, status))
-			} else {
-				buf.WriteString(fmt.Sprintf("- %s (%s)\n", item.Description, status))
-			}
-		}
-		buf.WriteString("\n")
-	}
-
-	return buf.String()
-}
 
 func WriteReportFile(content, outputDir string, reportDate time.Time, teamName string) (string, error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
@@ -98,26 +19,196 @@ func WriteReportFile(content, outputDir string, reportDate time.Time, teamName s
 	return path, os.WriteFile(path, []byte(content), 0644)
 }
 
-func groupByCategory(items []WorkItem) map[string][]WorkItem {
-	sections := make(map[string][]WorkItem)
-	for _, item := range items {
-		cat := item.Category
-		if cat == "" {
-			cat = "Uncategorized"
-		}
-		sections[cat] = append(sections[cat], item)
+func WriteEmailDraftFile(body, outputDir string, reportDate time.Time, subjectPrefix string) (string, error) {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return "", err
 	}
-	return sections
+	filename := fmt.Sprintf("%s_%s.eml", sanitizeFilename(subjectPrefix), reportDate.Format("20060102"))
+	path := filepath.Join(outputDir, filename)
+	subject := fmt.Sprintf("%s %s", subjectPrefix, reportDate.Format("20060102"))
+	content := buildEML(subject, body)
+	return path, os.WriteFile(path, []byte(content), 0644)
 }
 
-func uniqueAuthors(items []WorkItem) []string {
-	seen := make(map[string]bool)
-	var authors []string
-	for _, item := range items {
-		if !seen[item.Author] {
-			seen[item.Author] = true
-			authors = append(authors, item.Author)
+func buildEML(subject, body string) string {
+	const boundary = "reportbot-alt"
+	headers := []string{
+		"MIME-Version: 1.0",
+		fmt.Sprintf("Content-Type: multipart/alternative; boundary=%q", boundary),
+		fmt.Sprintf("Subject: %s", subject),
+	}
+	plain := normalizeCRLF(markdownToEmailPlain(body))
+	htmlBody := markdownToEmailHTML(body)
+
+	var out strings.Builder
+	out.WriteString(strings.Join(headers, "\r\n"))
+	out.WriteString("\r\n\r\n")
+	out.WriteString("--" + boundary + "\r\n")
+	out.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	out.WriteString("Content-Transfer-Encoding: 8bit\r\n\r\n")
+	out.WriteString(plain)
+	if !strings.HasSuffix(plain, "\r\n") {
+		out.WriteString("\r\n")
+	}
+	out.WriteString("\r\n--" + boundary + "\r\n")
+	out.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	out.WriteString("Content-Transfer-Encoding: 8bit\r\n\r\n")
+	out.WriteString(htmlBody)
+	out.WriteString("\r\n--" + boundary + "--\r\n")
+	return out.String()
+}
+
+func sanitizeFilename(s string) string {
+	replacer := strings.NewReplacer("/", "_", "\\", "_", ":", "_", "*", "_", "?", "_", "\"", "_", "<", "_", ">", "_", "|", "_")
+	return replacer.Replace(s)
+}
+
+func normalizeCRLF(s string) string {
+	normalized := strings.ReplaceAll(s, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\n", "\r\n")
+	return normalized
+}
+
+func bodyToHTML(body string) string {
+	escaped := html.EscapeString(strings.ReplaceAll(body, "\r\n", "\n"))
+	escaped = strings.ReplaceAll(escaped, "\n", "<br>\n")
+	return `<html><body style="font-family: Calibri, Arial, sans-serif; font-size: 11pt; color: #1f1f1f; line-height: 1.35;">` + escaped + `</body></html>`
+}
+
+func markdownToEmailPlain(body string) string {
+	var out []string
+	prevBlank := false
+	for _, line := range strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "#### ") {
+			line = strings.TrimSpace(strings.TrimLeft(trimmed, "# "))
+		}
+		line = strings.ReplaceAll(line, "**", "")
+		if strings.TrimSpace(line) == "" {
+			if prevBlank {
+				continue
+			}
+			prevBlank = true
+			out = append(out, "")
+			continue
+		}
+		prevBlank = false
+		out = append(out, line)
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n") + "\n"
+}
+
+var boldTokenRe = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+
+func markdownToEmailHTML(body string) string {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	var b strings.Builder
+	b.WriteString(`<html><body style="font-family: Calibri, Arial, sans-serif; font-size: 11pt; color: #1f1f1f; line-height: 1.35;">`)
+	levelHasOpenLI := make([]bool, 0, 4)
+	currentLevel := -1
+
+	closeToLevel := func(target int) {
+		for currentLevel > target {
+			if currentLevel < len(levelHasOpenLI) && levelHasOpenLI[currentLevel] {
+				b.WriteString(`</li>`)
+				levelHasOpenLI[currentLevel] = false
+			}
+			b.WriteString(`</ul>`)
+			levelHasOpenLI = levelHasOpenLI[:len(levelHasOpenLI)-1]
+			currentLevel--
 		}
 	}
-	return authors
+
+	closeAllLists := func() {
+		closeToLevel(0)
+		if currentLevel == 0 {
+			if levelHasOpenLI[0] {
+				b.WriteString(`</li>`)
+				levelHasOpenLI[0] = false
+			}
+			b.WriteString(`</ul>`)
+			levelHasOpenLI = levelHasOpenLI[:0]
+			currentLevel = -1
+		}
+	}
+
+	for _, raw := range lines {
+		line := strings.TrimRight(raw, " \t")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			closeAllLists()
+			b.WriteString(`<div style="height: 10px;"></div>`)
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "#### ") {
+			closeAllLists()
+			text := renderInlineBold(strings.TrimSpace(strings.TrimLeft(trimmed, "# ")))
+			b.WriteString(`<div style="font-weight: 700; margin: 12px 0 6px 0;">` + text + `</div>`)
+			continue
+		}
+
+		leading := len(line) - len(strings.TrimLeft(line, " "))
+		content := strings.TrimLeft(line, " ")
+		if strings.HasPrefix(content, "- ") {
+			textRaw := strings.TrimSpace(strings.TrimPrefix(content, "- "))
+			text := renderInlineBold(textRaw)
+			level := leading / 2
+			if level < 0 {
+				level = 0
+			}
+
+			if currentLevel == -1 {
+				for i := 0; i <= level; i++ {
+					b.WriteString(`<ul style="margin: 0 0 0 18px; padding-left: 18px; list-style-type: disc;">`)
+					levelHasOpenLI = append(levelHasOpenLI, false)
+					currentLevel++
+				}
+			} else if level > currentLevel {
+				for i := currentLevel + 1; i <= level; i++ {
+					b.WriteString(`<ul style="margin: 0 0 0 18px; padding-left: 18px; list-style-type: disc;">`)
+					levelHasOpenLI = append(levelHasOpenLI, false)
+					currentLevel++
+				}
+			} else if level < currentLevel {
+				closeToLevel(level)
+			}
+
+			if currentLevel >= 0 && levelHasOpenLI[currentLevel] {
+				b.WriteString(`</li>`)
+				levelHasOpenLI[currentLevel] = false
+			}
+			b.WriteString(`<li style="margin: 2px 0;">` + text)
+			levelHasOpenLI[currentLevel] = true
+			continue
+		}
+
+		closeAllLists()
+		text := renderInlineBold(strings.TrimSpace(content))
+		b.WriteString(`<div style="margin: 2px 0;">` + text + `</div>`)
+	}
+	closeAllLists()
+	b.WriteString(`</body></html>`)
+	return b.String()
+}
+
+func renderInlineBold(s string) string {
+	matches := boldTokenRe.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		return html.EscapeString(s)
+	}
+	var out strings.Builder
+	last := 0
+	for _, m := range matches {
+		if len(m) < 4 {
+			continue
+		}
+		out.WriteString(html.EscapeString(s[last:m[0]]))
+		out.WriteString("<strong>")
+		out.WriteString(html.EscapeString(s[m[2]:m[3]]))
+		out.WriteString("</strong>")
+		last = m[1]
+	}
+	out.WriteString(html.EscapeString(s[last:]))
+	return out.String()
 }

--- a/report_builder.go
+++ b/report_builder.go
@@ -1,0 +1,946 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+type ReportTemplate struct {
+	PrefixLines []string
+	Categories  []TemplateCategory
+}
+
+type TemplateCategory struct {
+	Name        string
+	Subsections []TemplateSubsection
+	MarkerLine  string
+}
+
+type TemplateSubsection struct {
+	Name       string
+	HeaderLine string
+	Items      []TemplateItem
+}
+
+type TemplateItem struct {
+	Author      string
+	Description string
+	TicketIDs   string
+	Status      string
+	IsNew       bool
+}
+
+type sectionOption struct {
+	ID         string
+	Category   int
+	Subsection int
+	Label      string
+}
+
+type loadStatus int
+
+const (
+	templateFromFile loadStatus = iota
+	templateFirstEver
+)
+
+var (
+	categoryHeadingRe = regexp.MustCompile(`^\s*####\s+(.+?)\s*$`)
+	topHeadingRe      = regexp.MustCompile(`^\s*###\s+(.+?)\s*$`)
+	subcategoryRe     = regexp.MustCompile(`^\s*-\s+\*\*(.+?)\*\*(.*)$`)
+	bulletLineRe      = regexp.MustCompile(`^\s*-\s+(.+?)\s*$`)
+	statusSuffixRe    = regexp.MustCompile(`\(([^)]+)\)\s*$`)
+	ticketPrefixRe    = regexp.MustCompile(`^\[([^\]]+)\]\s+`)
+	authorPrefixRe    = regexp.MustCompile(`^\*\*(.+?)\*\*\s*-\s*`)
+	trailingParenRe   = regexp.MustCompile(`\s*\(([^()]*)\)\s*$`)
+)
+
+var classifySectionsFn = CategorizeItemsToSections
+
+func BuildReportsFromLast(cfg Config, items []WorkItem, reportDate time.Time) (string, string, LLMUsage, error) {
+	template, status, err := loadTemplateForGeneration(cfg.ReportOutputDir, cfg.TeamName, reportDate)
+	if err != nil {
+		return "", "", LLMUsage{}, err
+	}
+	stripCurrentTeamTitleFromPrefix(template, cfg.TeamName)
+
+	merged := cloneTemplate(template)
+	trimDoneItems(merged)
+
+	options := templateOptions(template)
+	var decisions map[int64]LLMSectionDecision
+	llmUsage := LLMUsage{}
+	if len(options) > 0 && status != templateFirstEver {
+		existing := buildExistingItemContext(merged, options)
+		decisions, llmUsage, err = classifySectionsFn(cfg, items, options, existing)
+		if err != nil {
+			return "", "", llmUsage, err
+		}
+	}
+
+	confidenceThreshold := cfg.LLMConfidence
+	if confidenceThreshold <= 0 || confidenceThreshold > 1 {
+		confidenceThreshold = 0.70
+	}
+
+	mergeIncomingItems(merged, items, options, decisions, confidenceThreshold)
+	reorderTemplateItems(merged)
+
+	team := renderTeamMarkdown(merged, reportDate, cfg.TeamName)
+	boss := renderBossMarkdown(merged, reportDate, cfg.TeamName)
+	return team, boss, llmUsage, nil
+}
+
+func loadTemplateForGeneration(outputDir, teamName string, reportDate time.Time) (*ReportTemplate, loadStatus, error) {
+	lastPath, err := findLatestReportBefore(outputDir, teamName, reportDate)
+	if err != nil {
+		if strings.Contains(err.Error(), "no prior report found") {
+			return &ReportTemplate{
+				Categories: []TemplateCategory{
+					{
+						Name: "Undetermined",
+						Subsections: []TemplateSubsection{
+							{},
+						},
+					},
+				},
+			}, templateFirstEver, nil
+		}
+		return nil, templateFromFile, err
+	}
+	content, err := os.ReadFile(lastPath)
+	if err != nil {
+		return nil, templateFromFile, fmt.Errorf("reading last report: %w", err)
+	}
+	template := parseTemplate(string(content))
+	if len(template.Categories) == 0 {
+		return nil, templateFromFile, fmt.Errorf("last report has no categories: %s", lastPath)
+	}
+	return template, templateFromFile, nil
+}
+
+func findLatestReportBefore(outputDir, teamName string, reportDate time.Time) (string, error) {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return "", fmt.Errorf("reading report output dir: %w", err)
+	}
+
+	prefix := teamName + "_"
+	currentFile := fmt.Sprintf("%s_%s.md", teamName, reportDate.Format("20060102"))
+	type candidate struct {
+		path string
+		date time.Time
+	}
+	var candidates []candidate
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == currentFile || !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		raw := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".md")
+		d, err := time.Parse("20060102", raw)
+		if err != nil {
+			continue
+		}
+		if !d.Before(reportDate) {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			path: filepath.Join(outputDir, name),
+			date: d,
+		})
+	}
+
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("no prior report found in %s for team %s before %s", outputDir, teamName, reportDate.Format("20060102"))
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].date.After(candidates[j].date)
+	})
+	return candidates[0].path, nil
+}
+
+func parseTemplate(content string) *ReportTemplate {
+	template := &ReportTemplate{}
+	lines := strings.Split(content, "\n")
+
+	currentCat := -1
+	currentSub := -1
+	seenFirstCategory := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !seenFirstCategory {
+			template.PrefixLines = append(template.PrefixLines, line)
+		}
+		if trimmed == "" {
+			continue
+		}
+
+		// Preserve mid-report top headings (### ...), e.g. "### FAZ-BD",
+		// by storing them as marker categories in-place.
+		if m := topHeadingRe.FindStringSubmatch(line); len(m) == 2 && currentCat >= 0 {
+			template.Categories = append(template.Categories, TemplateCategory{
+				MarkerLine: "### " + strings.TrimSpace(m[1]),
+			})
+			currentCat = -1
+			currentSub = -1
+			continue
+		}
+
+		if m := categoryHeadingRe.FindStringSubmatch(line); len(m) == 2 {
+			if !seenFirstCategory && len(template.PrefixLines) > 0 {
+				template.PrefixLines = template.PrefixLines[:len(template.PrefixLines)-1]
+			}
+			seenFirstCategory = true
+			template.Categories = append(template.Categories, TemplateCategory{Name: strings.TrimSpace(m[1])})
+			currentCat = len(template.Categories) - 1
+			currentSub = -1
+			continue
+		}
+		if currentCat < 0 {
+			continue
+		}
+
+		if m := subcategoryRe.FindStringSubmatch(line); len(m) == 3 {
+			rest := strings.TrimSpace(m[2])
+			// Team-mode item lines look like: - **Author** - Description (status).
+			// Do not treat those as subsection headers.
+			if strings.HasPrefix(rest, "-") {
+				goto itemLine
+			}
+			sub := TemplateSubsection{
+				Name:       strings.TrimSpace(m[1]),
+				HeaderLine: strings.TrimSpace(line),
+			}
+			template.Categories[currentCat].Subsections = append(template.Categories[currentCat].Subsections, sub)
+			currentSub = len(template.Categories[currentCat].Subsections) - 1
+			continue
+		}
+
+	itemLine:
+		if m := bulletLineRe.FindStringSubmatch(line); len(m) == 2 {
+			if currentSub < 0 {
+				template.Categories[currentCat].Subsections = append(template.Categories[currentCat].Subsections, TemplateSubsection{})
+				currentSub = len(template.Categories[currentCat].Subsections) - 1
+			}
+			item := parseTemplateItem(m[1])
+			template.Categories[currentCat].Subsections[currentSub].Items = append(template.Categories[currentCat].Subsections[currentSub].Items, item)
+		}
+	}
+
+	return template
+}
+
+func parseTemplateItem(s string) TemplateItem {
+	text := strings.TrimSpace(s)
+	author := ""
+	if m := authorPrefixRe.FindStringSubmatch(text); len(m) == 2 {
+		author = strings.TrimSpace(m[1])
+		text = strings.TrimSpace(text[len(m[0]):])
+	}
+
+	status := ""
+	if m := statusSuffixRe.FindStringSubmatch(text); len(m) == 2 {
+		status = normalizeStatus(m[1])
+		text = strings.TrimSpace(text[:len(text)-len(m[0])])
+	}
+
+	ticketIDs := ""
+	if m := ticketPrefixRe.FindStringSubmatch(text); len(m) == 2 {
+		ticketIDs = strings.TrimSpace(m[1])
+		text = strings.TrimSpace(text[len(m[0]):])
+	}
+
+	return TemplateItem{
+		Author:      author,
+		Description: text,
+		TicketIDs:   ticketIDs,
+		Status:      status,
+	}
+}
+
+func templateOptions(t *ReportTemplate) []sectionOption {
+	var options []sectionOption
+	for ci, cat := range t.Categories {
+		for si, sub := range cat.Subsections {
+			label := cat.Name
+			if strings.TrimSpace(sub.Name) != "" {
+				label = cat.Name + " > " + sub.Name
+			}
+			options = append(options, sectionOption{
+				ID:         fmt.Sprintf("S%d_%d", ci, si),
+				Category:   ci,
+				Subsection: si,
+				Label:      label,
+			})
+		}
+	}
+	return options
+}
+
+func cloneTemplate(src *ReportTemplate) *ReportTemplate {
+	out := &ReportTemplate{
+		PrefixLines: append([]string(nil), src.PrefixLines...),
+		Categories:  make([]TemplateCategory, len(src.Categories)),
+	}
+	for i, cat := range src.Categories {
+		out.Categories[i].Name = cat.Name
+		out.Categories[i].MarkerLine = cat.MarkerLine
+		out.Categories[i].Subsections = make([]TemplateSubsection, len(cat.Subsections))
+		for j, sub := range cat.Subsections {
+			out.Categories[i].Subsections[j].Name = sub.Name
+			out.Categories[i].Subsections[j].HeaderLine = sub.HeaderLine
+			out.Categories[i].Subsections[j].Items = append([]TemplateItem(nil), sub.Items...)
+		}
+	}
+	return out
+}
+
+func trimDoneItems(t *ReportTemplate) {
+	for ci := range t.Categories {
+		for si := range t.Categories[ci].Subsections {
+			var filtered []TemplateItem
+			for _, item := range t.Categories[ci].Subsections[si].Items {
+				if statusBucket(item.Status) == 0 {
+					continue
+				}
+				filtered = append(filtered, item)
+			}
+			t.Categories[ci].Subsections[si].Items = filtered
+		}
+	}
+}
+
+func mergeIncomingItems(
+	t *ReportTemplate,
+	items []WorkItem,
+	options []sectionOption,
+	decisions map[int64]LLMSectionDecision,
+	confidenceThreshold float64,
+) {
+	optionByID := make(map[string]sectionOption, len(options))
+	for _, option := range options {
+		optionByID[option.ID] = option
+	}
+
+	undetermined, undeterminedMap := ensureUndeterminedSection(t)
+	itemByDupKey := buildDuplicateKeyIndex(t, options)
+
+	for _, item := range items {
+		decision := decisions[item.ID]
+		useLLM := decision.Confidence >= confidenceThreshold
+		status := chooseNormalizedStatus(item.Status, decision.NormalizedStatus, useLLM)
+		tickets := strings.TrimSpace(item.TicketIDs)
+		if useLLM && strings.TrimSpace(decision.TicketIDs) != "" {
+			tickets = strings.TrimSpace(decision.TicketIDs)
+		}
+		newItem := TemplateItem{
+			Author:      strings.TrimSpace(item.Author),
+			Description: strings.TrimSpace(item.Description),
+			TicketIDs:   tickets,
+			Status:      status,
+			IsNew:       true,
+		}
+
+		if useLLM {
+			if target, ok := itemByDupKey[decision.DuplicateOf]; ok {
+				(*target.items)[target.index] = mergeExistingItem((*target.items)[target.index], newItem)
+				continue
+			}
+		}
+
+		sectionID := "UND"
+		if useLLM && strings.TrimSpace(decision.SectionID) != "" {
+			sectionID = strings.TrimSpace(decision.SectionID)
+		}
+		option, ok := optionByID[sectionID]
+		if !ok {
+			key := itemIdentityKey(newItem)
+			if idx, exists := undeterminedMap[key]; exists {
+				undetermined.Items[idx] = mergeExistingItem(undetermined.Items[idx], newItem)
+				continue
+			}
+			undeterminedMap[key] = len(undetermined.Items)
+			undetermined.Items = append(undetermined.Items, newItem)
+			continue
+		}
+
+		itemsPtr := &t.Categories[option.Category].Subsections[option.Subsection].Items
+		found := -1
+		for idx := range *itemsPtr {
+			if itemIdentityKey((*itemsPtr)[idx]) == itemIdentityKey(newItem) {
+				found = idx
+				break
+			}
+		}
+		if found >= 0 {
+			(*itemsPtr)[found] = mergeExistingItem((*itemsPtr)[found], newItem)
+			continue
+		}
+		*itemsPtr = append(*itemsPtr, newItem)
+	}
+}
+
+func chooseNormalizedStatus(incomingStatus, llmStatus string, useLLM bool) string {
+	if useLLM {
+		switch normalizeStatus(llmStatus) {
+		case "done", "in testing", "in progress":
+			return normalizeStatus(llmStatus)
+		}
+	}
+	switch normalizeStatus(incomingStatus) {
+	case "done", "in testing", "in progress":
+		return normalizeStatus(incomingStatus)
+	default:
+		return "other"
+	}
+}
+
+type dupTarget struct {
+	items *[]TemplateItem
+	index int
+}
+
+func buildDuplicateKeyIndex(t *ReportTemplate, options []sectionOption) map[string]dupTarget {
+	optionByPos := make(map[[2]int]string, len(options))
+	for _, option := range options {
+		optionByPos[[2]int{option.Category, option.Subsection}] = option.ID
+	}
+
+	out := make(map[string]dupTarget)
+	serial := 1
+	for ci := range t.Categories {
+		for si := range t.Categories[ci].Subsections {
+			if _, ok := optionByPos[[2]int{ci, si}]; !ok {
+				continue
+			}
+			items := &t.Categories[ci].Subsections[si].Items
+			for ii := range *items {
+				key := fmt.Sprintf("K%d", serial)
+				out[key] = dupTarget{
+					items: items,
+					index: ii,
+				}
+				serial++
+			}
+		}
+	}
+	return out
+}
+
+func buildExistingItemContext(t *ReportTemplate, options []sectionOption) []existingItemContext {
+	optionByPos := make(map[[2]int]string, len(options))
+	for _, option := range options {
+		optionByPos[[2]int{option.Category, option.Subsection}] = option.ID
+	}
+
+	var out []existingItemContext
+	serial := 1
+	for ci := range t.Categories {
+		for si := range t.Categories[ci].Subsections {
+			sectionID, ok := optionByPos[[2]int{ci, si}]
+			if !ok {
+				continue
+			}
+			for _, item := range t.Categories[ci].Subsections[si].Items {
+				out = append(out, existingItemContext{
+					Key:         fmt.Sprintf("K%d", serial),
+					SectionID:   sectionID,
+					Description: item.Description,
+					Status:      item.Status,
+				})
+				serial++
+			}
+		}
+	}
+	return out
+}
+
+func ensureUndeterminedSection(t *ReportTemplate) (*TemplateSubsection, map[string]int) {
+	for ci := range t.Categories {
+		if strings.EqualFold(strings.TrimSpace(t.Categories[ci].Name), "Undetermined") {
+			if len(t.Categories[ci].Subsections) == 0 {
+				t.Categories[ci].Subsections = append(t.Categories[ci].Subsections, TemplateSubsection{})
+			}
+			return &t.Categories[ci].Subsections[0], buildItemIndex(t.Categories[ci].Subsections[0].Items)
+		}
+	}
+
+	t.Categories = append(t.Categories, TemplateCategory{
+		Name: "Undetermined",
+		Subsections: []TemplateSubsection{
+			{},
+		},
+	})
+	last := &t.Categories[len(t.Categories)-1].Subsections[0]
+	return last, make(map[string]int)
+}
+
+func buildItemIndex(items []TemplateItem) map[string]int {
+	index := make(map[string]int)
+	for i, item := range items {
+		index[itemIdentityKey(item)] = i
+	}
+	return index
+}
+
+func mergeExistingItem(existing, incoming TemplateItem) TemplateItem {
+	existing.Status = incoming.Status
+	existing.TicketIDs = incoming.TicketIDs
+	existing.Description = incoming.Description
+	if strings.TrimSpace(existing.Author) == "" {
+		existing.Author = incoming.Author
+	}
+	return existing
+}
+
+func reorderTemplateItems(t *ReportTemplate) {
+	for ci := range t.Categories {
+		for si := range t.Categories[ci].Subsections {
+			t.Categories[ci].Subsections[si].Items = reorderItems(t.Categories[ci].Subsections[si].Items)
+		}
+	}
+}
+
+func reorderItems(items []TemplateItem) []TemplateItem {
+	buckets := []int{0, 1, 2, 3}
+	var out []TemplateItem
+	for _, bucket := range buckets {
+		for _, item := range items {
+			if statusBucket(item.Status) == bucket && !item.IsNew {
+				out = append(out, item)
+			}
+		}
+		for _, item := range items {
+			if statusBucket(item.Status) == bucket && item.IsNew {
+				out = append(out, item)
+			}
+		}
+	}
+	return out
+}
+
+func itemIdentityKey(item TemplateItem) string {
+	return strings.ToLower(strings.TrimSpace(item.Description))
+}
+
+func renderTeamMarkdown(t *ReportTemplate, reportDate time.Time, teamName string) string {
+	var buf strings.Builder
+	if prefix := strings.TrimSpace(strings.Join(t.PrefixLines, "\n")); prefix != "" {
+		buf.WriteString(prefix)
+		buf.WriteString("\n\n")
+	}
+
+	for _, cat := range t.Categories {
+		if strings.TrimSpace(cat.MarkerLine) != "" {
+			buf.WriteString(strings.TrimSpace(cat.MarkerLine) + "\n\n")
+			continue
+		}
+		if len(cat.Subsections) == 0 {
+			continue
+		}
+		buf.WriteString(fmt.Sprintf("#### %s\n\n", cat.Name))
+		for _, sub := range cat.Subsections {
+			if strings.TrimSpace(sub.HeaderLine) != "" {
+				buf.WriteString(strings.TrimSpace(sub.HeaderLine) + "\n")
+			}
+			for _, item := range sub.Items {
+				prefix := "- "
+				if strings.TrimSpace(sub.HeaderLine) != "" {
+					prefix = "  - "
+				}
+				buf.WriteString(prefix + formatTeamItem(item) + "\n")
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(buf.String()) + "\n"
+}
+
+func renderBossMarkdown(t *ReportTemplate, reportDate time.Time, teamName string) string {
+	var buf strings.Builder
+	_ = reportDate
+	_ = teamName
+	if prefix := strings.TrimSpace(strings.Join(t.PrefixLines, "\n")); prefix != "" {
+		buf.WriteString(prefix)
+		buf.WriteString("\n\n")
+	}
+
+	for _, cat := range t.Categories {
+		if strings.TrimSpace(cat.MarkerLine) != "" {
+			buf.WriteString(strings.TrimSpace(cat.MarkerLine) + "\n\n")
+			continue
+		}
+		if len(cat.Subsections) == 0 {
+			continue
+		}
+		authors := categoryAuthors(cat)
+		catHeading := mergeCategoryHeadingAuthors(cat.Name, authors)
+		buf.WriteString(fmt.Sprintf("#### %s\n\n", catHeading))
+
+		for _, sub := range cat.Subsections {
+			if strings.TrimSpace(sub.HeaderLine) != "" {
+				buf.WriteString(strings.TrimSpace(sub.HeaderLine) + "\n")
+			}
+			for _, item := range sub.Items {
+				prefix := "- "
+				if strings.TrimSpace(sub.HeaderLine) != "" {
+					prefix = "  - "
+				}
+				buf.WriteString(prefix + formatBossItem(item) + "\n")
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(buf.String()) + "\n"
+}
+
+func renderBossPlainText(t *ReportTemplate, reportDate time.Time, teamName string) string {
+	var buf strings.Builder
+	buf.WriteString(fmt.Sprintf("%s %s\n\n", teamName, reportDate.Format("20060102")))
+	if prefix := strings.TrimSpace(strings.Join(t.PrefixLines, "\n")); prefix != "" {
+		for _, line := range strings.Split(prefix, "\n") {
+			clean := cleanBossLine(line)
+			if clean == "" {
+				buf.WriteString("\n")
+				continue
+			}
+			buf.WriteString(clean + "\n")
+		}
+		buf.WriteString("\n\n")
+	}
+
+	for _, cat := range t.Categories {
+		if strings.TrimSpace(cat.MarkerLine) != "" {
+			buf.WriteString(cleanBossLine(cat.MarkerLine) + "\n\n")
+			continue
+		}
+		if len(cat.Subsections) == 0 {
+			continue
+		}
+		authors := categoryAuthors(cat)
+		catHeading := mergeCategoryHeadingAuthors(cat.Name, authors)
+		buf.WriteString(catHeading + "\n")
+
+		for _, sub := range cat.Subsections {
+			if strings.TrimSpace(sub.HeaderLine) != "" {
+				buf.WriteString(cleanBossLine(sub.HeaderLine) + "\n")
+			}
+			for _, item := range sub.Items {
+				buf.WriteString(formatBossItem(item) + "\n")
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(buf.String()) + "\n"
+}
+
+func categoryAuthors(cat TemplateCategory) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, sub := range cat.Subsections {
+		for _, item := range sub.Items {
+			author := synthesizeName(item.Author)
+			if author == "" || seen[author] {
+				continue
+			}
+			seen[author] = true
+			out = append(out, author)
+		}
+	}
+	return out
+}
+
+func formatTeamItem(item TemplateItem) string {
+	status := normalizeStatus(item.Status)
+	if status == "" {
+		status = "done"
+	}
+	author := synthesizeName(item.Author)
+	description := synthesizeDescription(item.Description)
+	ticketPrefix := ""
+	if strings.TrimSpace(item.TicketIDs) != "" {
+		ticketPrefix = fmt.Sprintf("[%s] ", strings.TrimSpace(item.TicketIDs))
+	}
+	if author == "" {
+		return fmt.Sprintf("%s%s (%s)", ticketPrefix, description, status)
+	}
+	return fmt.Sprintf("**%s** - %s%s (%s)", author, ticketPrefix, description, status)
+}
+
+func formatBossItem(item TemplateItem) string {
+	status := normalizeStatus(item.Status)
+	if status == "" {
+		status = "done"
+	}
+	description := synthesizeDescription(item.Description)
+	ticketPrefix := ""
+	if strings.TrimSpace(item.TicketIDs) != "" {
+		ticketPrefix = fmt.Sprintf("[%s] ", strings.TrimSpace(item.TicketIDs))
+	}
+	return fmt.Sprintf("%s%s (%s)", ticketPrefix, description, status)
+}
+
+func normalizeStatus(status string) string {
+	s := strings.ToLower(strings.TrimSpace(status))
+	switch s {
+	case "done":
+		return "done"
+	case "in testing", "in test":
+		return "in testing"
+	case "in progress":
+		return "in progress"
+	default:
+		return s
+	}
+}
+
+func statusBucket(status string) int {
+	switch normalizeStatus(status) {
+	case "done":
+		return 0
+	case "in testing":
+		return 1
+	case "in progress":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func stripCurrentTeamTitleFromPrefix(t *ReportTemplate, teamName string) {
+	if len(t.PrefixLines) == 0 {
+		return
+	}
+	var out []string
+	for _, line := range t.PrefixLines {
+		if isCurrentTeamTitleLine(line, teamName) {
+			continue
+		}
+		out = append(out, line)
+	}
+	t.PrefixLines = out
+}
+
+func isCurrentTeamTitleLine(line, teamName string) bool {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "### ") {
+		return false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(line, "### "))
+	parts := strings.Fields(rest)
+	if len(parts) < 2 {
+		return false
+	}
+	last := parts[len(parts)-1]
+	if len(last) != 8 {
+		return false
+	}
+	for _, r := range last {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	name := strings.Join(parts[:len(parts)-1], " ")
+	return strings.EqualFold(strings.TrimSpace(name), strings.TrimSpace(teamName))
+}
+
+func synthesizeName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	parts := strings.Fields(strings.ToLower(name))
+	for i, p := range parts {
+		runes := []rune(p)
+		for j, r := range runes {
+			if unicode.IsLetter(r) {
+				runes[j] = unicode.ToUpper(r)
+				break
+			}
+		}
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, " ")
+}
+
+func synthesizeDescription(description string) string {
+	description = strings.TrimSpace(description)
+	if description == "" {
+		return ""
+	}
+	runes := []rune(description)
+	for i, r := range runes {
+		if unicode.IsLetter(r) {
+			runes[i] = unicode.ToUpper(r)
+			break
+		}
+	}
+	return string(runes)
+}
+
+func cleanBossLine(line string) string {
+	s := strings.TrimSpace(line)
+	if s == "" {
+		return ""
+	}
+	for _, prefix := range []string{"### ", "#### "} {
+		if strings.HasPrefix(s, prefix) {
+			s = strings.TrimSpace(strings.TrimPrefix(s, prefix))
+		}
+	}
+	if strings.HasPrefix(s, "- ") {
+		s = strings.TrimSpace(strings.TrimPrefix(s, "- "))
+	}
+	s = strings.ReplaceAll(s, "**", "")
+	return strings.TrimSpace(s)
+}
+
+func mergeCategoryHeadingAuthors(categoryName string, generatedAuthors []string) string {
+	base, existingAuthors := splitCategoryNameAndAuthors(categoryName)
+	merged := mergeAuthors(generatedAuthors, existingAuthors)
+	if len(merged) == 0 {
+		return strings.TrimSpace(base)
+	}
+	return fmt.Sprintf("%s (%s)", strings.TrimSpace(base), strings.Join(merged, ", "))
+}
+
+func splitCategoryNameAndAuthors(categoryName string) (string, []string) {
+	s := strings.TrimSpace(categoryName)
+	var groups [][]string
+	for {
+		m := trailingParenRe.FindStringSubmatch(s)
+		if len(m) != 2 {
+			break
+		}
+		inside := strings.TrimSpace(m[1])
+		if !looksLikeAuthorGroup(inside) {
+			break
+		}
+		var names []string
+		for _, p := range strings.Split(inside, ",") {
+			name := synthesizeName(strings.TrimSpace(p))
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+		if len(names) > 0 {
+			groups = append([][]string{names}, groups...)
+		}
+		s = strings.TrimSpace(strings.TrimSuffix(s, m[0]))
+	}
+	var existing []string
+	for _, g := range groups {
+		existing = append(existing, g...)
+	}
+	return s, existing
+}
+
+func looksLikeAuthorGroup(group string) bool {
+	if strings.TrimSpace(group) == "" {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(group))
+	statusWords := []string{"in progress", "in testing", "in test", "done", "qa"}
+	for _, w := range statusWords {
+		if strings.Contains(lower, w) {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeAuthors(primary []string, secondary []string) []string {
+	var out []string
+	add := func(name string) {
+		name = synthesizeName(name)
+		if name == "" {
+			return
+		}
+		for i, existing := range out {
+			if personNameEquivalent(existing, name) {
+				if len(strings.Fields(name)) > len(strings.Fields(existing)) {
+					out[i] = name
+				}
+				return
+			}
+		}
+		out = append(out, name)
+	}
+	for _, n := range primary {
+		add(n)
+	}
+	for _, n := range secondary {
+		add(n)
+	}
+	return out
+}
+
+func personNameEquivalent(a, b string) bool {
+	ta := nameTokens(a)
+	tb := nameTokens(b)
+	if len(ta) == 0 || len(tb) == 0 {
+		return false
+	}
+	return tokenSubset(ta, tb) || tokenSubset(tb, ta)
+}
+
+func nameTokens(s string) []string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return nil
+	}
+	replaced := strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return r
+		}
+		return ' '
+	}, s)
+	return strings.Fields(replaced)
+}
+
+func tokenSubset(a, b []string) bool {
+	set := make(map[string]struct{}, len(b))
+	for _, t := range b {
+		set[t] = struct{}{}
+	}
+	for _, t := range a {
+		if _, ok := set[t]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func collapseConsecutiveBlankLines(s string) string {
+	lines := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	var out []string
+	prevBlank := false
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			if prevBlank {
+				continue
+			}
+			prevBlank = true
+			out = append(out, "")
+			continue
+		}
+		prevBlank = false
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}

--- a/slack.go
+++ b/slack.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -13,6 +15,7 @@ import (
 )
 
 var statusRegex = regexp.MustCompile(`\(([^)]+)\)\s*$`)
+var delegatedAuthorRegex = regexp.MustCompile(`^\{([^{}]+)\}\s*`)
 
 func StartSlackBot(cfg Config, db *sql.DB, api *slack.Client) error {
 	client := socketmode.New(api)
@@ -25,6 +28,7 @@ func StartSlackBot(cfg Config, db *sql.DB, api *slack.Client) error {
 				if !ok {
 					continue
 				}
+				log.Printf("Slash command received: %s from user=%s channel=%s", cmd.Command, cmd.UserID, cmd.ChannelID)
 				client.Ack(*evt.Request)
 				go handleSlashCommand(client, api, db, cfg, cmd)
 			}
@@ -38,34 +42,63 @@ func StartSlackBot(cfg Config, db *sql.DB, api *slack.Client) error {
 func handleSlashCommand(client *socketmode.Client, api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
 	switch cmd.Command {
 	case "/report":
-		handleReport(api, db, cmd)
+		handleReport(api, db, cfg, cmd)
 	case "/fetch-mrs":
 		handleFetchMRs(api, db, cfg, cmd)
 	case "/generate-report":
 		handleGenerateReport(api, db, cfg, cmd)
 	case "/list-items":
-		handleListItems(api, db, cmd)
+		handleListItems(api, db, cfg, cmd)
+	case "/list-missing":
+		handleListMissing(api, db, cfg, cmd)
+	case "/nudge":
+		handleNudge(api, db, cfg, cmd)
+	case "/help":
+		handleHelp(api, cfg, cmd)
 	}
 }
 
-func handleReport(api *slack.Client, db *sql.DB, cmd slack.SlashCommand) {
+func handleReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
 	text := strings.TrimSpace(cmd.Text)
 	if text == "" {
-		postEphemeral(api, cmd, "Usage: /report <description> (status)\nExample: /report Fix consul timeout (done)")
+		postEphemeral(api, cmd, "Usage: /report <description> (status)\nExample: /report [mantis_id] Add pagination to user list API (done)")
 		return
 	}
 
-	status := "done"
-	description := text
+	author := cmd.UserName
+	if user, err := api.GetUserInfo(cmd.UserID); err == nil {
+		if user.Profile.DisplayName != "" {
+			author = user.Profile.DisplayName
+		} else if user.RealName != "" {
+			author = user.RealName
+		}
+	}
 
-	if match := statusRegex.FindStringSubmatch(text); len(match) > 1 {
+	// Manager-only delegated reporting syntax:
+	// /report {Member Name} Description (status)
+	reportText := text
+	if match := delegatedAuthorRegex.FindStringSubmatch(text); len(match) > 1 {
+		if cfg.IsManagerName(author) {
+			delegated := strings.TrimSpace(match[1])
+			remaining := strings.TrimSpace(text[len(match[0]):])
+			if delegated != "" && remaining != "" {
+				author = resolveDelegatedAuthorName(delegated, cfg.TeamMembers)
+				reportText = remaining
+			}
+		}
+	}
+
+	status := "done"
+	description := reportText
+
+	if match := statusRegex.FindStringSubmatch(reportText); len(match) > 1 {
 		status = strings.TrimSpace(match[1])
-		description = strings.TrimSpace(text[:len(text)-len(match[0])])
+		description = strings.TrimSpace(reportText[:len(reportText)-len(match[0])])
 	}
 
 	item := WorkItem{
 		Description: description,
-		Author:      cmd.UserName,
+		Author:      author,
 		Source:      "slack",
 		Status:      status,
 		ReportedAt:  time.Now(),
@@ -73,31 +106,72 @@ func handleReport(api *slack.Client, db *sql.DB, cmd slack.SlashCommand) {
 
 	if err := InsertWorkItem(db, item); err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error saving item: %v", err))
+		log.Printf("report insert error user=%s: %v", cmd.UserID, err)
 		return
 	}
 
-	postEphemeral(api, cmd, fmt.Sprintf("Recorded: %s [%s]", description, status))
+	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	pending, err := GetPendingSlackItemsByAuthorAndDateRange(db, author, monday, nextMonday)
+	if err != nil {
+		log.Printf("report pending lookup error user=%s author=%s: %v", cmd.UserID, author, err)
+		postEphemeral(api, cmd, fmt.Sprintf("Recorded: %s [%s]", description, status))
+		return
+	}
+
+	msg := fmt.Sprintf("Recorded: %s (%s) for %s", description, status, author)
+	if len(pending) > 0 {
+		msg += "\n\nYour not-done items this week:"
+		limit := 8
+		for i, p := range pending {
+			if i >= limit {
+				msg += fmt.Sprintf("\n- ... and %d more", len(pending)-limit)
+				break
+			}
+			msg += fmt.Sprintf("\n- %s (%s)", p.Description, normalizeStatus(p.Status))
+		}
+	}
+	postEphemeral(api, cmd, msg)
+	log.Printf("report saved user=%s author=%s status=%s", cmd.UserID, author, status)
 }
 
 func handleFetchMRs(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
-	if !cfg.IsManager(cmd.UserID) {
+	isManager, err := isManagerUser(api, cfg, cmd.UserID)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error checking permissions: %v", err))
+		log.Printf("fetch-mrs auth error user=%s: %v", cmd.UserID, err)
+		return
+	}
+	if !isManager {
 		postEphemeral(api, cmd, "Sorry, only managers can use this command.")
+		log.Printf("fetch-mrs denied user=%s", cmd.UserID)
 		return
 	}
 
-	monday, nextMonday := CurrentWeekRange()
+	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	log.Printf("fetch-mrs range %s - %s", monday.Format("2006-01-02"), nextMonday.Format("2006-01-02"))
 
 	postEphemeral(api, cmd, fmt.Sprintf("Fetching merged MRs for %s to %s...",
 		monday.Format("Jan 2"), nextMonday.AddDate(0, 0, -1).Format("Jan 2")))
 
-	mrs, err := FetchMergedMRs(cfg, monday, nextMonday)
+	mrs, err := FetchMRs(cfg, monday, nextMonday)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error fetching MRs: %v", err))
+		log.Printf("fetch-mrs error: %v", err)
 		return
 	}
+	log.Printf("fetch-mrs fetched=%d", len(mrs))
+
+	teamMembers := cfg.TeamMembers
 
 	var newItems []WorkItem
 	for _, mr := range mrs {
+		if len(teamMembers) > 0 {
+			if !anyNameMatches(teamMembers, mr.AuthorName) && !anyNameMatches(teamMembers, mr.Author) {
+				log.Printf("fetch-mrs skipped non-team author=%s username=%s", mr.AuthorName, mr.Author)
+				continue
+			}
+		}
+
 		exists, err := SourceRefExists(db, mr.WebURL)
 		if err != nil {
 			log.Printf("Error checking MR existence: %v", err)
@@ -112,29 +186,39 @@ func handleFetchMRs(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCo
 			Author:      mr.AuthorName,
 			Source:      "gitlab",
 			SourceRef:   mr.WebURL,
-			Status:      "done",
-			ReportedAt:  mr.MergedAt,
+			Status:      mapMRStatus(mr),
+			ReportedAt:  mrReportedAt(mr),
 		})
 	}
 
 	if len(newItems) == 0 {
 		postEphemeral(api, cmd, fmt.Sprintf("Found %d merged MRs, all already tracked.", len(mrs)))
+		log.Printf("fetch-mrs all tracked")
 		return
 	}
 
 	inserted, err := InsertWorkItems(db, newItems)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error storing MRs: %v", err))
+		log.Printf("fetch-mrs insert error: %v", err)
 		return
 	}
 
-	postEphemeral(api, cmd, fmt.Sprintf("Fetched %d merged MRs (%d new, %d already tracked)",
+	postEphemeral(api, cmd, fmt.Sprintf("Fetched %d MRs (merged+open) (%d new, %d already tracked)",
 		len(mrs), inserted, len(mrs)-inserted))
+	log.Printf("fetch-mrs inserted=%d skipped=%d", inserted, len(mrs)-inserted)
 }
 
 func handleGenerateReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
-	if !cfg.IsManager(cmd.UserID) {
+	isManager, err := isManagerUser(api, cfg, cmd.UserID)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error checking permissions: %v", err))
+		log.Printf("generate-report auth error user=%s: %v", cmd.UserID, err)
+		return
+	}
+	if !isManager {
 		postEphemeral(api, cmd, "Sorry, only managers can use this command.")
+		log.Printf("generate-report denied user=%s", cmd.UserID)
 		return
 	}
 
@@ -144,72 +228,96 @@ func handleGenerateReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.S
 	}
 
 	postEphemeral(api, cmd, fmt.Sprintf("Generating report (mode: %s)...", mode))
+	log.Printf("generate-report mode=%s", mode)
 
-	monday, nextMonday := CurrentWeekRange()
+	monday, nextMonday := ReportWeekRange(cfg, time.Now())
 	items, err := GetItemsByDateRange(db, monday, nextMonday)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error loading items: %v", err))
+		log.Printf("generate-report load error: %v", err)
 		return
 	}
+	log.Printf("generate-report items=%d", len(items))
 
 	if len(items) == 0 {
 		postEphemeral(api, cmd, "No work items found for this week.")
 		return
 	}
 
-	// Categorize uncategorized items
-	var uncategorized []WorkItem
-	for _, item := range items {
-		if item.Category == "" {
-			uncategorized = append(uncategorized, item)
-		}
-	}
-
-	if len(uncategorized) > 0 {
-		categoryMap, ticketMap, err := CategorizeItems(cfg, uncategorized)
-		if err != nil {
-			postEphemeral(api, cmd, fmt.Sprintf("Warning: AI categorization failed: %v. Generating with 'Uncategorized' items.", err))
-		} else {
-			if err := UpdateCategories(db, categoryMap); err != nil {
-				log.Printf("Error updating categories: %v", err)
-			}
-			if err := UpdateTicketIDs(db, ticketMap); err != nil {
-				log.Printf("Error updating ticket IDs: %v", err)
-			}
-
-			// Reload items with updated categories
-			items, err = GetItemsByDateRange(db, monday, nextMonday)
-			if err != nil {
-				postEphemeral(api, cmd, fmt.Sprintf("Error reloading items: %v", err))
-				return
-			}
-		}
-	}
-
-	report := GenerateReport(items, monday, mode, cfg.Categories, cfg.TeamName)
-
-	filePath, err := WriteReportFile(report, cfg.ReportOutputDir, monday, cfg.TeamName)
+	teamReport, bossReport, llmUsage, err := BuildReportsFromLast(cfg, items, monday)
 	if err != nil {
-		log.Printf("Error writing report file: %v", err)
-	}
-
-	// Post report to channel
-	_, _, err = api.PostMessage(cmd.ChannelID, slack.MsgOptionText("```\n"+report+"\n```", false))
-	if err != nil {
-		log.Printf("Error posting report: %v", err)
-		postEphemeral(api, cmd, "Error posting report to channel. Check bot permissions.")
+		postEphemeral(api, cmd, fmt.Sprintf("Error building report: %v", err))
+		log.Printf("report build error: %v", err)
 		return
 	}
 
-	msg := fmt.Sprintf("Report generated with %d items (mode: %s)", len(items), mode)
+	var filePath string
+	var fileTitle string
+	if mode == "boss" {
+		filePath, err = WriteEmailDraftFile(bossReport, cfg.ReportOutputDir, monday, cfg.TeamName)
+		fileTitle = fmt.Sprintf("%s report email draft", cfg.TeamName)
+	} else {
+		filePath, err = WriteReportFile(teamReport, cfg.ReportOutputDir, monday, cfg.TeamName)
+		fileTitle = fmt.Sprintf("%s team report", cfg.TeamName)
+	}
+	if err != nil {
+		log.Printf("Error writing report file: %v", err)
+		postEphemeral(api, cmd, fmt.Sprintf("Error writing report file: %v", err))
+		return
+	}
+	log.Printf("generate-report team-report-length=%d boss-report-length=%d file=%s mode=%s", len(teamReport), len(bossReport), filePath, mode)
+
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		log.Printf("Error stating report file: %v", err)
+		postEphemeral(api, cmd, fmt.Sprintf("Error reading generated file: %v", err))
+		return
+	}
+	if fi.Size() <= 0 {
+		log.Printf("Error uploading report file: generated file is empty path=%s", filePath)
+		postEphemeral(api, cmd, "Error uploading report file: generated file is empty.")
+		return
+	}
+
+	tokenUsedText := formatTokenCount(llmUsage.TotalTokens())
+
+	_, err = api.UploadFileV2(slack.UploadFileV2Parameters{
+		File:           filePath,
+		FileSize:       int(fi.Size()),
+		Filename:       filepath.Base(filePath),
+		Channel:        cmd.ChannelID,
+		Title:          fileTitle,
+		InitialComment: fmt.Sprintf("Generated report for week starting %s (mode: %s, tokens used: %s)", monday.Format("2006-01-02"), mode, tokenUsedText),
+	})
+	if err != nil {
+		log.Printf("Error uploading report file: %v", err)
+		postEphemeral(api, cmd, "Error uploading report file to channel. Check bot permissions.")
+		return
+	}
+
+	msg := fmt.Sprintf("Report generated with %d items (mode: %s, tokens used: %s)", len(items), mode, tokenUsedText)
 	if filePath != "" {
 		msg += fmt.Sprintf("\nSaved to: %s", filePath)
 	}
 	postEphemeral(api, cmd, msg)
+	log.Printf("generate-report done items=%d", len(items))
 }
 
-func handleListItems(api *slack.Client, db *sql.DB, cmd slack.SlashCommand) {
-	monday, nextMonday := CurrentWeekRange()
+func formatTokenCount(tokens int64) string {
+	if tokens < 1000 {
+		return fmt.Sprintf("%d", tokens)
+	}
+	rounded := (tokens + 50) / 100
+	whole := rounded / 10
+	decimal := rounded % 10
+	if decimal == 0 {
+		return fmt.Sprintf("%dk", whole)
+	}
+	return fmt.Sprintf("%d.%dk", whole, decimal)
+}
+
+func handleListItems(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
+	monday, nextMonday := ReportWeekRange(cfg, time.Now())
 	items, err := GetItemsByDateRange(db, monday, nextMonday)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error: %v", err))
@@ -219,6 +327,7 @@ func handleListItems(api *slack.Client, db *sql.DB, cmd slack.SlashCommand) {
 	if len(items) == 0 {
 		postEphemeral(api, cmd, fmt.Sprintf("No items for this week (%s - %s)",
 			monday.Format("Jan 2"), nextMonday.AddDate(0, 0, -1).Format("Jan 2")))
+		log.Printf("list-items empty")
 		return
 	}
 
@@ -240,6 +349,98 @@ func handleListItems(api *slack.Client, db *sql.DB, cmd slack.SlashCommand) {
 	}
 
 	postEphemeral(api, cmd, sb.String())
+	log.Printf("list-items count=%d", len(items))
+}
+
+func handleListMissing(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
+	isManager, err := isManagerUser(api, cfg, cmd.UserID)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error checking permissions: %v", err))
+		log.Printf("list-missing auth error user=%s: %v", cmd.UserID, err)
+		return
+	}
+	if !isManager {
+		postEphemeral(api, cmd, "Sorry, only managers can use this command.")
+		log.Printf("list-missing denied user=%s", cmd.UserID)
+		return
+	}
+
+	if len(cfg.TeamMembers) == 0 {
+		postEphemeral(api, cmd, "No team_members configured.")
+		return
+	}
+
+	memberIDs, unresolved, err := resolveUserIDs(api, cfg.TeamMembers)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error resolving team members: %v", err))
+		log.Printf("list-missing resolve error: %v", err)
+		return
+	}
+
+	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	authors, err := GetSlackAuthorsByDateRange(db, monday, nextMonday)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error loading items: %v", err))
+		log.Printf("list-missing load error: %v", err)
+		return
+	}
+
+	var reported []string
+	for author := range authors {
+		reported = append(reported, author)
+	}
+
+	var missing []string
+	for _, userID := range memberIDs {
+		user, err := api.GetUserInfo(userID)
+		if err != nil {
+			missing = append(missing, fmt.Sprintf("<@%s> (lookup failed)", userID))
+			continue
+		}
+
+		candidates := []string{user.Name, user.RealName, user.Profile.DisplayName}
+		hasReported := false
+		for _, c := range candidates {
+			if c != "" && anyNameMatches(reported, c) {
+				hasReported = true
+				break
+			}
+		}
+		if !hasReported {
+			display := user.Profile.DisplayName
+			if display == "" {
+				display = user.RealName
+			}
+			if display == "" {
+				display = user.Name
+			}
+			if display == "" {
+				display = userID
+			}
+			missing = append(missing, fmt.Sprintf("%s (<@%s>)", display, userID))
+		}
+	}
+
+	for _, name := range unresolved {
+		missing = append(missing, fmt.Sprintf("%s (not found)", name))
+	}
+
+	if len(missing) == 0 {
+		postEphemeral(api, cmd, fmt.Sprintf("Everyone has reported this week (%s - %s).",
+			monday.Format("Jan 2"), nextMonday.AddDate(0, 0, -1).Format("Jan 2")))
+		log.Printf("list-missing none")
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*Missing reports for %s - %s* (%d total)\n\n",
+		monday.Format("Jan 2"), nextMonday.AddDate(0, 0, -1).Format("Jan 2"), len(missing)))
+	for _, m := range missing {
+		sb.WriteString(fmt.Sprintf("- %s\n", m))
+	}
+
+	postEphemeral(api, cmd, sb.String())
+	log.Printf("list-missing count=%d", len(missing))
 }
 
 func postEphemeral(api *slack.Client, cmd slack.SlashCommand, text string) {
@@ -247,4 +448,237 @@ func postEphemeral(api *slack.Client, cmd slack.SlashCommand, text string) {
 	if err != nil {
 		log.Printf("Error posting ephemeral: %v", err)
 	}
+}
+
+func handleNudge(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCommand) {
+	isManager, err := isManagerUser(api, cfg, cmd.UserID)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error checking permissions: %v", err))
+		log.Printf("nudge auth error user=%s: %v", cmd.UserID, err)
+		return
+	}
+	if !isManager {
+		postEphemeral(api, cmd, "Sorry, only managers can use this command.")
+		log.Printf("nudge denied user=%s", cmd.UserID)
+		return
+	}
+
+	if len(cfg.TeamMembers) == 0 {
+		postEphemeral(api, cmd, "No team_members configured.")
+		return
+	}
+
+	memberIDs, unresolved, err := resolveUserIDs(api, cfg.TeamMembers)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error resolving team members: %v", err))
+		log.Printf("nudge resolve error: %v", err)
+		return
+	}
+	if len(unresolved) > 0 {
+		postEphemeral(api, cmd, fmt.Sprintf("Warning: could not resolve: %s", strings.Join(unresolved, ", ")))
+		log.Printf("nudge unresolved: %s", strings.Join(unresolved, ", "))
+	}
+
+	text := strings.TrimSpace(cmd.Text)
+	if text != "" {
+		targetIDs, err := resolveNudgeTargets(api, text)
+		if err != nil {
+			postEphemeral(api, cmd, err.Error())
+			log.Printf("nudge target resolve error: %v", err)
+			return
+		}
+		for _, id := range targetIDs {
+			if !containsString(memberIDs, id) {
+				postEphemeral(api, cmd, "Error: mentioned user is not in team_members.")
+				log.Printf("nudge target not in team_members id=%s", id)
+				return
+			}
+		}
+		sendNudges(api, cfg, targetIDs, cfg.ReportChannelID)
+		postEphemeral(api, cmd, fmt.Sprintf("Sent nudges to %d team member(s).", len(targetIDs)))
+		log.Printf("nudge sent target-count=%d", len(targetIDs))
+		return
+	}
+
+	// No parameter: nudge only members who haven't reported this week.
+	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	authors, err := GetSlackAuthorsByDateRange(db, monday, nextMonday)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error loading items: %v", err))
+		log.Printf("nudge load error: %v", err)
+		return
+	}
+
+	var reported []string
+	for author := range authors {
+		reported = append(reported, author)
+	}
+
+	var missingIDs []string
+	for _, userID := range memberIDs {
+		user, err := api.GetUserInfo(userID)
+		if err != nil {
+			continue
+		}
+		candidates := []string{user.Name, user.RealName, user.Profile.DisplayName}
+		hasReported := false
+		for _, c := range candidates {
+			if c != "" && anyNameMatches(reported, c) {
+				hasReported = true
+				break
+			}
+		}
+		if !hasReported {
+			missingIDs = append(missingIDs, userID)
+		}
+	}
+
+	if len(missingIDs) == 0 {
+		postEphemeral(api, cmd, fmt.Sprintf("Everyone has reported this week (%s - %s).",
+			monday.Format("Jan 2"), nextMonday.AddDate(0, 0, -1).Format("Jan 2")))
+		log.Printf("nudge none missing")
+		return
+	}
+
+	sendNudges(api, cfg, missingIDs, cfg.ReportChannelID)
+	postEphemeral(api, cmd, fmt.Sprintf("Sent nudges to %d team member(s).", len(missingIDs)))
+	log.Printf("nudge sent missing-count=%d", len(missingIDs))
+}
+
+func handleHelp(api *slack.Client, cfg Config, cmd slack.SlashCommand) {
+	isManager, err := isManagerUser(api, cfg, cmd.UserID)
+	if err != nil {
+		postEphemeral(api, cmd, fmt.Sprintf("Error checking permissions: %v", err))
+		log.Printf("help auth error user=%s: %v", cmd.UserID, err)
+		return
+	}
+
+	lines := []string{
+		"ReportBot Commands",
+		"",
+		"/report <description> (status) - Report a work item.",
+		"  Example: /report [mantis_id] Add pagination to user list API (done)",
+		"",
+		"/list-items - List this week's items.",
+		"/help - Show this help.",
+	}
+
+	if isManager {
+		lines = append(lines,
+			"",
+			"/fetch-mrs - Fetch merged GitLab MRs for this week.",
+			"/generate-report team|boss - Generate weekly report.",
+			"/list-missing - List team members who haven't reported this week.",
+			"/nudge [@name] - Nudge missing members, or a specific user.",
+		)
+	}
+
+	postEphemeral(api, cmd, strings.Join(lines, "\n"))
+}
+
+func isManagerUser(api *slack.Client, cfg Config, userID string) (bool, error) {
+	user, err := api.GetUserInfo(userID)
+	if err != nil {
+		return false, err
+	}
+
+	candidates := []string{
+		user.RealName,
+		user.Profile.DisplayName,
+		user.Name,
+	}
+	for _, c := range candidates {
+		if c != "" && cfg.IsManagerName(c) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func resolveNudgeTargets(api *slack.Client, text string) ([]string, error) {
+	mentionID := extractMentionID(text)
+	if mentionID != "" {
+		return []string{mentionID}, nil
+	}
+
+	name := strings.TrimSpace(strings.TrimPrefix(text, "@"))
+	if name == "" {
+		return nil, fmt.Errorf("Error: invalid nudge target.")
+	}
+	ids, unresolved, err := resolveUserIDs(api, []string{name})
+	if err != nil {
+		return nil, fmt.Errorf("Error resolving user: %v", err)
+	}
+	if len(ids) == 0 || len(unresolved) > 0 {
+		return nil, fmt.Errorf("Error: mentioned user was not found.")
+	}
+	return ids, nil
+}
+
+func extractMentionID(text string) string {
+	re := regexp.MustCompile(`<@([A-Z0-9]+)(?:\\|[^>]+)?>`)
+	if match := re.FindStringSubmatch(text); len(match) > 1 {
+		return match[1]
+	}
+	return ""
+}
+
+func containsString(vals []string, target string) bool {
+	for _, v := range vals {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveDelegatedAuthorName(input string, teamMembers []string) string {
+	input = strings.TrimSpace(input)
+	if input == "" || len(teamMembers) == 0 {
+		return input
+	}
+
+	normalizedInput := normalizeTextToken(input)
+
+	// 1) Exact match first.
+	for _, member := range teamMembers {
+		if normalizeTextToken(member) == normalizedInput {
+			return member
+		}
+	}
+
+	// 2) Fuzzy match using token-subset logic in both directions.
+	var matches []string
+	for _, member := range teamMembers {
+		if nameMatches(input, member) || nameMatches(member, input) {
+			matches = append(matches, member)
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0]
+	}
+
+	// Ambiguous/no match: keep caller input unchanged.
+	return input
+}
+
+func mapMRStatus(mr GitLabMR) string {
+	if mr.State == "opened" {
+		return "in progress"
+	}
+	return "done"
+}
+
+func mrReportedAt(mr GitLabMR) time.Time {
+	if mr.State == "opened" && !mr.UpdatedAt.IsZero() {
+		return mr.UpdatedAt
+	}
+	if !mr.MergedAt.IsZero() {
+		return mr.MergedAt
+	}
+	if !mr.CreatedAt.IsZero() {
+		return mr.CreatedAt
+	}
+	return time.Now()
 }

--- a/slack_users.go
+++ b/slack_users.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+func resolveUserIDs(api *slack.Client, identifiers []string) ([]string, []string, error) {
+	var ids []string
+	var names []string
+
+	for _, raw := range identifiers {
+		val := strings.TrimSpace(raw)
+		if val == "" {
+			continue
+		}
+		if isLikelySlackID(val) {
+			ids = append(ids, val)
+		} else {
+			names = append(names, val)
+		}
+	}
+
+	if len(names) == 0 {
+		log.Printf("resolve users: ids=%d names=0", len(ids))
+		return uniqueStrings(ids), nil, nil
+	}
+
+	users, err := api.GetUsers()
+	if err != nil {
+		log.Printf("resolve users: get users error: %v", err)
+		return uniqueStrings(ids), names, err
+	}
+
+	nameToID := make(map[string]string)
+	for _, user := range users {
+		addName := func(n string) {
+			n = strings.ToLower(strings.TrimSpace(n))
+			if n == "" {
+				return
+			}
+			if _, exists := nameToID[n]; !exists {
+				nameToID[n] = user.ID
+			}
+		}
+		addName(user.Name)
+		addName(user.RealName)
+		addName(user.Profile.DisplayName)
+	}
+
+	var unresolved []string
+	for _, name := range names {
+		key := strings.ToLower(strings.TrimSpace(name))
+		if id, ok := nameToID[key]; ok {
+			ids = append(ids, id)
+		} else {
+			unresolved = append(unresolved, name)
+		}
+	}
+
+	log.Printf("resolve users: ids=%d unresolved=%d", len(ids), len(unresolved))
+	return uniqueStrings(ids), unresolved, nil
+}
+
+func isLikelySlackID(val string) bool {
+	if len(val) < 9 {
+		return false
+	}
+	for i, r := range val {
+		if i == 0 {
+			if r != 'U' && r != 'W' {
+				return false
+			}
+			continue
+		}
+		if (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func uniqueStrings(vals []string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, v := range vals {
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+var parenPattern = regexp.MustCompile(`\([^)]*\)|（[^）]*）`)
+
+func normalizeNameTokens(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = parenPattern.ReplaceAllString(s, " ")
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune(' ')
+		}
+	}
+	parts := strings.Fields(b.String())
+	if len(parts) == 0 {
+		return nil
+	}
+	return parts
+}
+
+func nameMatches(teamEntry, candidate string) bool {
+	teamTokens := normalizeNameTokens(teamEntry)
+	candTokens := normalizeNameTokens(candidate)
+	if len(teamTokens) == 0 || len(candTokens) == 0 {
+		return false
+	}
+	candSet := make(map[string]bool, len(candTokens))
+	for _, t := range candTokens {
+		candSet[t] = true
+	}
+	for _, t := range teamTokens {
+		if !candSet[t] {
+			return false
+		}
+	}
+	return true
+}
+
+func anyNameMatches(teamEntries []string, candidate string) bool {
+	for _, entry := range teamEntries {
+		if nameMatches(entry, candidate) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Refactor weekly report builder to derive output from previous report structure.
- Improve LLM classification pipeline with usage tracking and glossary support.
- Add manager/member command enhancements, including /rpt alias and interactive /list-items edit/delete actions.
- Switch Slack file uploads to UploadFileV2 and fix upload compatibility.
- Add Docker Compose support and update documentation.
- Remove tracked config example file and ignore local llm_glossary.yaml.

## Notes
- Local artifacts and generated report files are intentionally excluded from commits.
- Branch history was rewritten and force-pushed to remove sensitive names in tests.