### PR TITLE
debug: log all socket mode events to diagnose member_joined

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -48,6 +48,7 @@ func StartSlackBot(cfg Config, db *sql.DB, api *slack.Client) error {
 
 	go func() {
 		for evt := range client.Events {
+			log.Printf("socket-mode event type=%s", evt.Type)
 			switch evt.Type {
 			case socketmode.EventTypeSlashCommand:
 				cmd, ok := evt.Data.(slack.SlashCommand)


### PR DESCRIPTION
## Summary

- Adds a debug log line for every socket mode event to diagnose why `member_joined_channel` events may not be arriving

## Test plan

- [ ] Rebuild and run the bot
- [ ] Have someone join the channel and check logs for `socket-mode event type=events_api`
- [ ] Remove this debug log once the issue is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)