### PR TITLE
refactor: replace global time.Local mutation with explicit cfg.Location

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	MondayCutoffTime string   `yaml:"monday_cutoff_time"`
 	Timezone         string   `yaml:"timezone"`
 	TeamName         string   `yaml:"team_name"`
+
+	Location *time.Location `yaml:"-"` // computed from Timezone, not from YAML
 }
 
 func LoadConfig() Config {
@@ -168,13 +170,13 @@ func LoadConfig() Config {
 	}
 
 	if strings.EqualFold(cfg.Timezone, "Local") {
-		cfg.Timezone = time.Local.String()
+		cfg.Location = time.Local
 	} else {
 		loc, err := time.LoadLocation(cfg.Timezone)
 		if err != nil {
 			log.Fatalf("invalid timezone '%s': %v", cfg.Timezone, err)
 		}
-		time.Local = loc
+		cfg.Location = loc
 	}
 
 	if _, _, err := parseClock(cfg.MondayCutoffTime); err != nil {

--- a/models.go
+++ b/models.go
@@ -36,8 +36,8 @@ type ReportSection struct {
 }
 
 // CurrentWeekRange returns Monday 00:00:00 and next Monday 00:00:00 for the current calendar week.
-func CurrentWeekRange() (time.Time, time.Time) {
-	now := time.Now()
+func CurrentWeekRange(loc *time.Location) (time.Time, time.Time) {
+	now := time.Now().In(loc)
 	return CurrentWeekRangeAt(now)
 }
 

--- a/nudge.go
+++ b/nudge.go
@@ -52,7 +52,7 @@ func StartNudgeScheduler(cfg Config, api *slack.Client) {
 
 	go func() {
 		for {
-			now := time.Now()
+			now := time.Now().In(cfg.Location)
 			next := nextWeekday(now, weekday, hour, min)
 			wait := next.Sub(now)
 			log.Printf("Next nudge at %s (in %s)", next.Format("Mon Jan 2 15:04"), wait.Round(time.Minute))
@@ -76,7 +76,7 @@ func nextWeekday(now time.Time, day time.Weekday, hour, min int) time.Time {
 }
 
 func sendNudges(api *slack.Client, cfg Config, memberIDs []string, reportChannelID string) {
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	channelRef := ""
 	if reportChannelID != "" {
 		channelRef = fmt.Sprintf(" Please report in <#%s>.", reportChannelID)

--- a/slack.go
+++ b/slack.go
@@ -175,7 +175,7 @@ func handleReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashComm
 		}
 	}
 
-	items, parseErr := parseReportItems(reportText, author)
+	items, parseErr := parseReportItems(reportText, author, cfg.Location)
 	if parseErr != nil {
 		postEphemeral(api, cmd, parseErr.Error())
 		log.Printf("report parse error user=%s: %v", cmd.UserID, parseErr)
@@ -198,7 +198,7 @@ func handleReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashComm
 		}
 	}
 
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	weekItems, err := GetSlackItemsByAuthorAndDateRange(db, author, monday, nextMonday)
 	if err != nil {
 		log.Printf("report weekly items lookup error user=%s author=%s: %v", cmd.UserID, author, err)
@@ -233,7 +233,7 @@ func handleReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashComm
 	log.Printf("report saved user=%s author=%s count=%d", cmd.UserID, author, len(items))
 }
 
-func parseReportItems(reportText, author string) ([]WorkItem, error) {
+func parseReportItems(reportText, author string, loc *time.Location) ([]WorkItem, error) {
 	lines := strings.Split(strings.ReplaceAll(reportText, "\r\n", "\n"), "\n")
 	trimmed := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -261,7 +261,7 @@ func parseReportItems(reportText, author string) ([]WorkItem, error) {
 		return nil, fmt.Errorf("Usage: /report <description> (status)")
 	}
 
-	now := time.Now()
+	now := time.Now().In(loc)
 	items := make([]WorkItem, 0, len(trimmed))
 	for _, line := range trimmed {
 		status := "done"
@@ -299,7 +299,7 @@ func handleFetchMRs(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCo
 		return
 	}
 
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	log.Printf("fetch-mrs range %s - %s", monday.Format("2006-01-02"), nextMonday.Format("2006-01-02"))
 
 	postEphemeral(api, cmd, fmt.Sprintf("Fetching merged MRs for %s to %s...",
@@ -339,7 +339,7 @@ func handleFetchMRs(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashCo
 			Source:      "gitlab",
 			SourceRef:   mr.WebURL,
 			Status:      mapMRStatus(mr),
-			ReportedAt:  mrReportedAt(mr),
+			ReportedAt:  mrReportedAt(mr, cfg.Location),
 		})
 	}
 
@@ -382,7 +382,7 @@ func handleGenerateReport(api *slack.Client, db *sql.DB, cfg Config, cmd slack.S
 	postEphemeral(api, cmd, fmt.Sprintf("Generating report (mode: %s)...", mode))
 	log.Printf("generate-report mode=%s", mode)
 
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	items, err := GetItemsByDateRange(db, monday, nextMonday)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error loading items: %v", err))
@@ -516,7 +516,7 @@ func handleListItems(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashC
 }
 
 func renderListItems(api *slack.Client, db *sql.DB, cfg Config, channelID, userID string, page int) {
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	items, err := GetItemsByDateRange(db, monday, nextMonday)
 	if err != nil {
 		postEphemeralTo(api, channelID, userID, fmt.Sprintf("Error: %v", err))
@@ -664,7 +664,7 @@ func handleListMissing(api *slack.Client, db *sql.DB, cfg Config, cmd slack.Slas
 		return
 	}
 
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	authors, err := GetSlackAuthorsByDateRange(db, monday, nextMonday)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error loading items: %v", err))
@@ -891,7 +891,7 @@ func handleViewSubmission(api *slack.Client, db *sql.DB, cfg Config, cb slack.In
 	if status == "other" {
 		status = item.Status
 	}
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	if !itemInRange(item, monday, nextMonday) {
 		return
 	}
@@ -937,7 +937,7 @@ func deleteItemAction(api *slack.Client, db *sql.DB, cfg Config, channelID, user
 		postEphemeralTo(api, channelID, userID, "Item not found.")
 		return
 	}
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	if !itemInRange(item, monday, nextMonday) {
 		postEphemeralTo(api, channelID, userID, "You can only modify this week's items.")
 		return
@@ -963,7 +963,7 @@ func openEditModal(api *slack.Client, db *sql.DB, cfg Config, triggerID, channel
 		postEphemeralTo(api, channelID, userID, "Item not found.")
 		return
 	}
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	if !itemInRange(item, monday, nextMonday) {
 		postEphemeralTo(api, channelID, userID, "You can only modify this week's items.")
 		return
@@ -1104,7 +1104,7 @@ func openDeleteModal(api *slack.Client, db *sql.DB, cfg Config, triggerID, chann
 		postEphemeralTo(api, channelID, userID, "Item not found.")
 		return
 	}
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	if !itemInRange(item, monday, nextMonday) {
 		postEphemeralTo(api, channelID, userID, "You can only modify this week's items.")
 		return
@@ -1224,7 +1224,7 @@ func handleNudge(api *slack.Client, db *sql.DB, cfg Config, cmd slack.SlashComma
 	}
 
 	// No parameter: nudge only members who haven't reported this week.
-	monday, nextMonday := ReportWeekRange(cfg, time.Now())
+	monday, nextMonday := ReportWeekRange(cfg, time.Now().In(cfg.Location))
 	authors, err := GetSlackAuthorsByDateRange(db, monday, nextMonday)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error loading items: %v", err))
@@ -1390,7 +1390,7 @@ func mapMRStatus(mr GitLabMR) string {
 	return "done"
 }
 
-func mrReportedAt(mr GitLabMR) time.Time {
+func mrReportedAt(mr GitLabMR, loc *time.Location) time.Time {
 	if mr.State == "opened" && !mr.UpdatedAt.IsZero() {
 		return mr.UpdatedAt
 	}
@@ -1400,13 +1400,13 @@ func mrReportedAt(mr GitLabMR) time.Time {
 	if !mr.CreatedAt.IsZero() {
 		return mr.CreatedAt
 	}
-	return time.Now()
+	return time.Now().In(loc)
 }
 
 // --- Correction helpers ---
 
 func loadSectionOptionsForModal(cfg Config) []sectionOption {
-	template, _, err := loadTemplateForGeneration(cfg.ReportOutputDir, cfg.TeamName, time.Now())
+	template, _, err := loadTemplateForGeneration(cfg.ReportOutputDir, cfg.TeamName, time.Now().In(cfg.Location))
 	if err != nil {
 		log.Printf("edit modal load template error (non-fatal): %v", err)
 		return nil
@@ -1610,7 +1610,7 @@ func handleRetrospective(api *slack.Client, db *sql.DB, cfg Config, cmd slack.Sl
 		return
 	}
 
-	fourWeeksAgo := time.Now().AddDate(0, 0, -28)
+	fourWeeksAgo := time.Now().In(cfg.Location).AddDate(0, 0, -28)
 	corrections, err := GetRecentCorrections(db, fourWeeksAgo, 200)
 	if err != nil {
 		postEphemeral(api, cmd, fmt.Sprintf("Error loading corrections: %v", err))


### PR DESCRIPTION
## Summary
- Add `Location *time.Location` field to `Config`, computed from the `timezone` setting
- Remove the `time.Local = loc` global mutation in `LoadConfig()`
- All `time.Now()` call sites now use `.In(cfg.Location)` for explicit timezone handling
- Thread `loc` parameter to `CurrentWeekRange()`, `parseReportItems()`, and `mrReportedAt()` helpers

This eliminates fragile process-global state that could cause test flakiness and surprising side effects.

## Test plan
- [ ] Configure `timezone: "Local"` → verify behavior unchanged (uses system timezone)
- [ ] Configure `timezone: "Asia/Tokyo"` → verify all date ranges, nudge scheduling, and report timestamps use JST
- [ ] Run `go test -v ./...` → all 18 tests pass
- [ ] Grep for `time.Local =` → no remaining mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)