### PR TITLE
chore: gitignore .DS_Store, .claude/, and .gomodcache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ override/
 reportbot-reports/
 prod/
 docker-compose-*
+.DS_Store
+.claude/
+.gomodcache/


### PR DESCRIPTION
## Summary

- Add `.DS_Store`, `.claude/`, and `.gomodcache/` to `.gitignore` to prevent accidental commits of OS artifacts, Claude Code session data, and local Go module cache

## Test plan

- [ ] `git status` shows no untracked files for the ignored patterns
- [ ] Existing tracked files are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)